### PR TITLE
[Feature] 카테고리별 도서 페이지

### DIFF
--- a/src/main/java/shop/bookbom/front/domain/book/adapter/BookAdapter.java
+++ b/src/main/java/shop/bookbom/front/domain/book/adapter/BookAdapter.java
@@ -1,4 +1,4 @@
-package shop.bookbom.front.domain.book.adaptor;
+package shop.bookbom.front.domain.book.adapter;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.data.domain.Pageable;
@@ -16,7 +16,7 @@ import shop.bookbom.front.domain.book.dto.response.BookDetailResponse;
 import shop.bookbom.front.domain.book.dto.response.BookSearchResponse;
 
 @FeignClient(value = "BOOKBOM-FRONT-BOOK", path = "/shop", url = "${bookbom.gateway-url}")
-public interface BookAdaptor {
+public interface BookAdapter {
     @PutMapping("/book/update/new")
     CommonResponse<Void> save(@RequestBody BookAddRequest bookAddRequest);
 

--- a/src/main/java/shop/bookbom/front/domain/book/adapter/BookRestTemplateAdapter.java
+++ b/src/main/java/shop/bookbom/front/domain/book/adapter/BookRestTemplateAdapter.java
@@ -1,10 +1,10 @@
-package shop.bookbom.front.domain.book.adaptor;
+package shop.bookbom.front.domain.book.adapter;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 /**
- * packageName    : shop.bookbom.front.domain.book.adaptor
+ * packageName    : shop.bookbom.front.domain.book.adapter
  * fileName       : BookRestTemplateAdaptor
  * author         : UuLaptop
  * date           : 2024-04-15
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class BookRestTemplateAdaptor {
+public class BookRestTemplateAdapter {
 //    private static final ParameterizedTypeReference<CommonResponse<CartInfoResponse>> CART_INFO_RESPONSE =
 //            new ParameterizedTypeReference<>() {
 //            };

--- a/src/main/java/shop/bookbom/front/domain/book/adaptor/BookAdaptor.java
+++ b/src/main/java/shop/bookbom/front/domain/book/adaptor/BookAdaptor.java
@@ -1,21 +1,43 @@
 package shop.bookbom.front.domain.book.adaptor;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import shop.bookbom.front.common.CommonResponse;
 import shop.bookbom.front.domain.book.dto.request.BookAddRequest;
+import shop.bookbom.front.domain.book.dto.request.BookUpdateRequest;
 import shop.bookbom.front.domain.book.dto.response.BookDetailResponse;
+import shop.bookbom.front.domain.book.dto.response.BookSearchResponse;
 
 @FeignClient(value = "BOOKBOM-FRONT-BOOK", path = "/shop", url = "${bookbom.gateway-url}")
 public interface BookAdaptor {
     @PutMapping("/book/update/new")
     CommonResponse<Void> save(@RequestBody BookAddRequest bookAddRequest);
 
+    @PutMapping("/book/update/{id}")
+    public CommonResponse<Void> updateBook(@RequestBody BookUpdateRequest bookUpdateRequest,
+                                           @PathVariable("id") Long bookId);
+
+    @DeleteMapping("/book/delete/{id}")
+    public CommonResponse<Void> deleteBook(@PathVariable("id") Long bookId);
+
     @GetMapping("/book/detail/{id}")
     CommonResponse<BookDetailResponse> get(@PathVariable("id") Long bookId);
 
+//    @GetMapping("/books/best")
+//    CommonResponse<Page<BookMediumResponse>> getBest(Pageable pageable);
+//
+//    @GetMapping("/books/all")
+//    CommonResponse<Page<BookMediumResponse>> getAll(Pageable pageable);
 
+    @GetMapping("/books/category/{categoryId}")
+    CommonResponse<Page<BookSearchResponse>> getByCategoryId(
+            @PathVariable("categoryId") Long categoryId,
+            String sortCondition,
+            Pageable pageable);
 }

--- a/src/main/java/shop/bookbom/front/domain/book/adaptor/BookAdaptor.java
+++ b/src/main/java/shop/bookbom/front/domain/book/adaptor/BookAdaptor.java
@@ -1,13 +1,14 @@
 package shop.bookbom.front.domain.book.adaptor;
 
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import shop.bookbom.front.common.CommonPage;
 import shop.bookbom.front.common.CommonResponse;
 import shop.bookbom.front.domain.book.dto.request.BookAddRequest;
 import shop.bookbom.front.domain.book.dto.request.BookUpdateRequest;
@@ -36,8 +37,8 @@ public interface BookAdaptor {
 //    CommonResponse<Page<BookMediumResponse>> getAll(Pageable pageable);
 
     @GetMapping("/books/category/{categoryId}")
-    CommonResponse<Page<BookSearchResponse>> getByCategoryId(
+    CommonResponse<CommonPage<BookSearchResponse>> getByCategoryId(
             @PathVariable("categoryId") Long categoryId,
-            String sortCondition,
-            Pageable pageable);
+            Pageable pageable,
+            @RequestParam String sortCondition);
 }

--- a/src/main/java/shop/bookbom/front/domain/book/controller/CategoryBooksController.java
+++ b/src/main/java/shop/bookbom/front/domain/book/controller/CategoryBooksController.java
@@ -9,31 +9,40 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import shop.bookbom.front.domain.book.dto.response.BookSearchResponse;
 import shop.bookbom.front.domain.book.service.BookService;
+import shop.bookbom.front.domain.category.dto.response.CategoryNameAndChildResponse;
+import shop.bookbom.front.domain.category.service.CategoryService;
 
 @Controller
 @RequiredArgsConstructor
 public class CategoryBooksController {
     private final BookService bookService;
+    private final CategoryService categoryService;
 
-    @GetMapping("/category")
-    public String index(Model model,
+    @GetMapping("/category/{id}")
+    public String index(@PathVariable(value = "id") Long categoryId,
                         @PageableDefault(size = 5) Pageable pageable,
-                        @RequestParam(value = "id") Long bookId,
-                        @RequestParam(required = false) String sorted) {
+                        @RequestParam(required = false) String sorted,
+                        Model model) {
         String sortCondition = getSortCondition(sorted);
 
-        Page<BookSearchResponse> response =
-                bookService.getBooksByCategoryId(bookId, sortCondition, pageable).getResult();
+        Page<BookSearchResponse> bookResponse =
+                bookService.getBooksByCategoryId(categoryId, pageable, sortCondition).getResult();
 
-        model.addAttribute("books", response.getContent());
-        model.addAttribute("currentPage", response.getNumber());
-        model.addAttribute("pageSize", response.getPageable().getPageSize());
-        model.addAttribute("totalPages", response.getTotalPages());
-        model.addAttribute("totalItems", response.getTotalElements());
-        model.addAttribute("size", response.getSize());
+        CategoryNameAndChildResponse categoryResponse =
+                categoryService.getCategoryNameAndChildCategoriesByCategoryId(categoryId);
+
+        model.addAttribute("category", categoryResponse);
+
+        model.addAttribute("books", bookResponse.getContent());
+        model.addAttribute("currentPage", bookResponse.getNumber());
+        model.addAttribute("pageSize", bookResponse.getPageable().getPageSize());
+        model.addAttribute("totalPages", bookResponse.getTotalPages());
+        model.addAttribute("totalItems", bookResponse.getTotalElements());
+        model.addAttribute("size", bookResponse.getSize());
         model.addAttribute("sorted", sorted);
 
         return "page/category/categorybooks";

--- a/src/main/java/shop/bookbom/front/domain/book/controller/CategoryBooksController.java
+++ b/src/main/java/shop/bookbom/front/domain/book/controller/CategoryBooksController.java
@@ -1,0 +1,42 @@
+package shop.bookbom.front.domain.book.controller;
+
+import static shop.bookbom.front.domain.search.controller.SearchController.getSortCondition;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import shop.bookbom.front.domain.book.dto.response.BookSearchResponse;
+import shop.bookbom.front.domain.book.service.BookService;
+
+@Controller
+@RequiredArgsConstructor
+public class CategoryBooksController {
+    private final BookService bookService;
+
+    @GetMapping("/category")
+    public String index(Model model,
+                        @PageableDefault(size = 5) Pageable pageable,
+                        @RequestParam(value = "id") Long bookId,
+                        @RequestParam(required = false) String sorted) {
+        String sortCondition = getSortCondition(sorted);
+
+        Page<BookSearchResponse> response =
+                bookService.getBooksByCategoryId(bookId, sortCondition, pageable).getResult();
+
+        model.addAttribute("books", response.getContent());
+        model.addAttribute("currentPage", response.getNumber());
+        model.addAttribute("pageSize", response.getPageable().getPageSize());
+        model.addAttribute("totalPages", response.getTotalPages());
+        model.addAttribute("totalItems", response.getTotalElements());
+        model.addAttribute("size", response.getSize());
+        model.addAttribute("sorted", sorted);
+
+        return "page/category/categorybooks";
+    }
+
+}

--- a/src/main/java/shop/bookbom/front/domain/book/dto/response/BookCategoryResponse.java
+++ b/src/main/java/shop/bookbom/front/domain/book/dto/response/BookCategoryResponse.java
@@ -1,0 +1,44 @@
+package shop.bookbom.front.domain.book.dto.response;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import shop.bookbom.front.domain.file.dto.FileDTO;
+import shop.bookbom.front.domain.pointrate.dto.PointRateSimpleInformation;
+import shop.bookbom.front.domain.publisher.entity.dto.PublisherSimpleInformation;
+import shop.bookbom.front.domain.tag.dto.TagDTO;
+import shop.bookbom.front.review.dto.ReviewResponse;
+import shop.bookbom.front.review.dto.ReviewStatisticsResponse;
+
+/**
+ * packageName    : shop.bookbom.front.domain.book.dto.response
+ * fileName       : BookCategoryResponse
+ * author         : UuLaptop
+ * date           : 2024-04-24
+ * description    : BookMediumResponse
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-04-24        UuLaptop       최초 생성
+ */
+@Getter
+@NoArgsConstructor
+public class BookCategoryResponse {
+    private Long id;
+    private String title;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate pubDate;
+    private Integer cost;
+    private Integer discountCost;
+    private PublisherSimpleInformation publisher;
+    private PointRateSimpleInformation pointRate;
+    private List<AuthorResponse> authors = new ArrayList<>();
+    private List<TagDTO> tags = new ArrayList<>();
+    private List<FileDTO> files = new ArrayList<>();
+    private List<ReviewResponse> reviews = new ArrayList<>();
+    // 리뷰 평점, 리뷰 총갯수
+    private ReviewStatisticsResponse reviewStatistics;
+}

--- a/src/main/java/shop/bookbom/front/domain/book/service/BookService.java
+++ b/src/main/java/shop/bookbom/front/domain/book/service/BookService.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import shop.bookbom.front.common.CommonPage;
 import shop.bookbom.front.common.CommonResponse;
-import shop.bookbom.front.domain.book.adaptor.BookAdaptor;
+import shop.bookbom.front.domain.book.adapter.BookAdapter;
 import shop.bookbom.front.domain.book.dto.request.BookAddRequest;
 import shop.bookbom.front.domain.book.dto.response.BookDetailResponse;
 import shop.bookbom.front.domain.book.dto.response.BookSearchResponse;
@@ -14,7 +14,7 @@ import shop.bookbom.front.domain.book.dto.response.BookSearchResponse;
 @Service
 @RequiredArgsConstructor
 public class BookService {
-    private final BookAdaptor bookAdaptor;
+    private final BookAdapter bookAdaptor;
 
     public CommonResponse<Void> addBook(BookAddRequest bookAddRequest) {
         return bookAdaptor.save(bookAddRequest);

--- a/src/main/java/shop/bookbom/front/domain/book/service/BookService.java
+++ b/src/main/java/shop/bookbom/front/domain/book/service/BookService.java
@@ -2,41 +2,32 @@ package shop.bookbom.front.domain.book.service;
 
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import shop.bookbom.front.common.CommonResponse;
 import shop.bookbom.front.domain.book.adaptor.BookAdaptor;
 import shop.bookbom.front.domain.book.dto.request.BookAddRequest;
 import shop.bookbom.front.domain.book.dto.response.BookDetailResponse;
+import shop.bookbom.front.domain.book.dto.response.BookSearchResponse;
 
-/**
- * The type Book service.
- */
 @Service
 @RequiredArgsConstructor
 public class BookService {
     private final BookAdaptor bookAdaptor;
 
-    /**
-     * methodName : putBook
-     * author : 전석준
-     * description :
-     *
-     * @param book add request
-     * @return common response
-     */
-    public CommonResponse<Void> putBook(BookAddRequest bookAddRequest) {
+    public CommonResponse<Void> addBook(BookAddRequest bookAddRequest) {
         return bookAdaptor.save(bookAddRequest);
     }
 
-    /**
-     * methodName : getBook
-     * author : 전석준
-     * description :
-     *
-     * @param book id
-     * @return common response
-     */
     public CommonResponse<BookDetailResponse> getBook(Long bookId) {
         return bookAdaptor.get(bookId);
     }
+
+    public CommonResponse<Page<BookSearchResponse>> getBooksByCategoryId(Long categoryId,
+                                                                         String sortCondition,
+                                                                         Pageable pageable) {
+        return bookAdaptor.getByCategoryId(categoryId, sortCondition, pageable);
+    }
+
 }

--- a/src/main/java/shop/bookbom/front/domain/book/service/BookService.java
+++ b/src/main/java/shop/bookbom/front/domain/book/service/BookService.java
@@ -2,9 +2,9 @@ package shop.bookbom.front.domain.book.service;
 
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import shop.bookbom.front.common.CommonPage;
 import shop.bookbom.front.common.CommonResponse;
 import shop.bookbom.front.domain.book.adaptor.BookAdaptor;
 import shop.bookbom.front.domain.book.dto.request.BookAddRequest;
@@ -24,10 +24,10 @@ public class BookService {
         return bookAdaptor.get(bookId);
     }
 
-    public CommonResponse<Page<BookSearchResponse>> getBooksByCategoryId(Long categoryId,
-                                                                         String sortCondition,
-                                                                         Pageable pageable) {
-        return bookAdaptor.getByCategoryId(categoryId, sortCondition, pageable);
+    public CommonResponse<CommonPage<BookSearchResponse>> getBooksByCategoryId(Long categoryId,
+                                                                               Pageable pageable,
+                                                                               String sortCondition) {
+        return bookAdaptor.getByCategoryId(categoryId, pageable, sortCondition);
     }
 
 }

--- a/src/main/java/shop/bookbom/front/domain/category/adapter/CategoryAdapter.java
+++ b/src/main/java/shop/bookbom/front/domain/category/adapter/CategoryAdapter.java
@@ -1,4 +1,4 @@
-package shop.bookbom.front.domain.category.adaptor;
+package shop.bookbom.front.domain.category.adapter;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,7 +10,7 @@ import shop.bookbom.front.domain.category.dto.response.CategoryDepthResponse;
 import shop.bookbom.front.domain.category.dto.response.CategoryNameAndChildResponse;
 
 @FeignClient(value = "BOOKBOM-FRONT-CATEGORY", path = "/shop", url = "${bookbom.gateway-url}")
-public interface CategoryAdaptor {
+public interface CategoryAdapter {
 
     @GetMapping("/category/all")
     CommonResponse<CategoryDepthResponse> getAllCategories();

--- a/src/main/java/shop/bookbom/front/domain/category/adaptor/CategoryAdaptor.java
+++ b/src/main/java/shop/bookbom/front/domain/category/adaptor/CategoryAdaptor.java
@@ -7,6 +7,7 @@ import shop.bookbom.front.common.CommonListResponse;
 import shop.bookbom.front.common.CommonResponse;
 import shop.bookbom.front.domain.category.dto.CategoryDTO;
 import shop.bookbom.front.domain.category.dto.response.CategoryDepthResponse;
+import shop.bookbom.front.domain.category.dto.response.CategoryNameAndChildResponse;
 
 @FeignClient(value = "BOOKBOM-FRONT-CATEGORY", path = "/shop", url = "${bookbom.gateway-url}")
 public interface CategoryAdaptor {
@@ -19,5 +20,10 @@ public interface CategoryAdaptor {
 
     @GetMapping("/category/{parentId}")
     CommonListResponse<CategoryDTO> getChildCategoriesOf(@PathVariable("parentId") Long parentId);
+
+    @GetMapping("/category/nameandchild/{parentId}")
+    CommonResponse<CategoryNameAndChildResponse> getNameAndChildCategoriesOf(
+            @PathVariable("parentId") Long parentId);
+
 
 }

--- a/src/main/java/shop/bookbom/front/domain/category/dto/response/CategoryNameAndChildResponse.java
+++ b/src/main/java/shop/bookbom/front/domain/category/dto/response/CategoryNameAndChildResponse.java
@@ -1,0 +1,24 @@
+package shop.bookbom.front.domain.category.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * packageName    : shop.bookbom.front.domain.category.dto.response
+ * fileName       : CategoryNameAndChildResponse
+ * author         : UuLaptop
+ * date           : 2024-04-25
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-04-25        UuLaptop       최초 생성
+ */
+@Getter
+@NoArgsConstructor
+public class CategoryNameAndChildResponse {
+    private Long id;
+    private String name;
+    List<CategoryNameAndChildResponse> children;
+}

--- a/src/main/java/shop/bookbom/front/domain/category/service/CategoryService.java
+++ b/src/main/java/shop/bookbom/front/domain/category/service/CategoryService.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import shop.bookbom.front.common.CommonListResponse;
 import shop.bookbom.front.common.CommonResponse;
-import shop.bookbom.front.domain.category.adaptor.CategoryAdaptor;
+import shop.bookbom.front.domain.category.adapter.CategoryAdapter;
 import shop.bookbom.front.domain.category.dto.CategoryDTO;
 import shop.bookbom.front.domain.category.dto.response.CategoryDepthResponse;
 import shop.bookbom.front.domain.category.dto.response.CategoryNameAndChildResponse;
@@ -14,7 +14,7 @@ import shop.bookbom.front.domain.category.dto.response.CategoryNameAndChildRespo
 @Service
 @RequiredArgsConstructor
 public class CategoryService {
-    private final CategoryAdaptor categoryAdaptor;
+    private final CategoryAdapter categoryAdaptor;
 
     public CategoryDepthResponse getAllCategories() {
         CommonResponse<?> response = categoryAdaptor.getAllCategories();

--- a/src/main/java/shop/bookbom/front/domain/category/service/CategoryService.java
+++ b/src/main/java/shop/bookbom/front/domain/category/service/CategoryService.java
@@ -1,6 +1,7 @@
 package shop.bookbom.front.domain.category.service;
 
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import shop.bookbom.front.common.CommonListResponse;
@@ -8,6 +9,7 @@ import shop.bookbom.front.common.CommonResponse;
 import shop.bookbom.front.domain.category.adaptor.CategoryAdaptor;
 import shop.bookbom.front.domain.category.dto.CategoryDTO;
 import shop.bookbom.front.domain.category.dto.response.CategoryDepthResponse;
+import shop.bookbom.front.domain.category.dto.response.CategoryNameAndChildResponse;
 
 @Service
 @RequiredArgsConstructor
@@ -27,9 +29,16 @@ public class CategoryService {
     }
 
     public List<CategoryDTO> getChildCategoriesById(Long categoryId) {
-        CommonListResponse<?> response = categoryAdaptor.getChildCategoriesOf(categoryId);
+        CommonListResponse<CategoryDTO> response = categoryAdaptor.getChildCategoriesOf(categoryId);
         // null 없으므로 체크하지 않음
-        return (List<CategoryDTO>) response.getResult();
+        return Objects.requireNonNull(response).getResult();
+    }
+
+    public CategoryNameAndChildResponse getCategoryNameAndChildCategoriesByCategoryId(Long categoryId) {
+        CommonResponse<CategoryNameAndChildResponse> response =
+                categoryAdaptor.getNameAndChildCategoriesOf(categoryId);
+        // null 없으므로 체크하지 않음
+        return Objects.requireNonNull(response).getResult();
     }
 
 }

--- a/src/main/java/shop/bookbom/front/domain/category/service/CategoryService.java
+++ b/src/main/java/shop/bookbom/front/domain/category/service/CategoryService.java
@@ -31,4 +31,5 @@ public class CategoryService {
         // null 없으므로 체크하지 않음
         return (List<CategoryDTO>) response.getResult();
     }
+
 }

--- a/src/main/java/shop/bookbom/front/domain/search/controller/SearchController.java
+++ b/src/main/java/shop/bookbom/front/domain/search/controller/SearchController.java
@@ -45,7 +45,7 @@ public class SearchController {
     }
 
 
-    private static String getSortCondition(String sorted) {
+    public static String getSortCondition(String sorted) {
         if (StringUtils.hasText(sorted)) {
             return SearchSort.valueOf(sorted.toUpperCase()).name();
         }

--- a/src/main/java/shop/bookbom/front/review/dto/ReviewResponse.java
+++ b/src/main/java/shop/bookbom/front/review/dto/ReviewResponse.java
@@ -1,0 +1,23 @@
+package shop.bookbom.front.review.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * packageName    : shop.bookbom.front.review.dto
+ * fileName       : ReviewResponse
+ * author         : UuLaptop
+ * date           : 2024-04-24
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 2024-04-24        UuLaptop       최초 생성
+ */
+@Getter
+@NoArgsConstructor
+public class ReviewResponse {
+    private Long id;
+    private int rate;
+    private String content;
+}

--- a/src/main/resources/static/css/page/category/categorybooks.css
+++ b/src/main/resources/static/css/page/category/categorybooks.css
@@ -1,0 +1,328 @@
+
+.result {
+    font-size: 1.8rem;
+    font-weight: 700;
+}
+
+.search-result {
+    font-size: 2.4rem;
+}
+
+.card-title {
+    font-weight: 700;
+}
+
+.navbar {
+    margin-bottom: 50px;
+}
+
+.search-condition {
+    display: flex;
+    flex-direction: column;
+}
+
+.search-condition h5 {
+    font-weight: 700;
+    font-size: 25px;
+}
+
+.form-check {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-size: 18px;
+}
+
+.search-condition {
+    display: flex;
+    flex-direction: column;
+}
+
+.form-check-input {
+    width: 1.25rem;
+    height: 1.25rem;
+    margin-right: 10px;
+}
+
+
+.form-check-label {
+    margin-bottom: 0;
+    display: flex;
+    align-items: center;
+}
+
+.card {
+    margin-bottom: 20px;
+}
+
+.card-body {
+    padding: 20px;
+}
+
+.card-img-top {
+    margin-bottom: 20px;
+}
+
+.img-thumbnail {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* 상품 가격 */
+.original-price {
+    margin-left: 3px;
+    text-decoration: line-through;
+    color: grey;
+    margin-right: 10px;
+}
+
+.card-text {
+    margin-bottom: 2px;
+}
+
+.btn-div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.btn-div button {
+    width: 70%;
+    height: 50px;
+    margin-bottom: 10px;
+}
+
+.quantity-and-buttons {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+/* 수량 버튼 */
+
+.btn-div :first-child {
+    padding: 0;
+}
+
+.card input[type="checkbox"] {
+    transform: scale(1.5);
+    margin-top: 10px;
+}
+
+.btn-outline-secondary {
+    margin-left: 8px;
+}
+
+/*.custom-btn {*/
+/*    background-color: #f5f5f5; !* Light gray *!*/
+/*    border: 1px solid rgba(204, 204, 204, 0.36); !* Light gray border *!*/
+/*    transition: background-color 0.3s, border-color 0.3s;*/
+/*}*/
+
+/*.custom-btn:hover {*/
+/*    background-color: #e0e0e0; !* Slightly darker gray *!*/
+/*    border-color: #bfbfbf; !* Dark gray border *!*/
+/*}*/
+.g-0 {
+    justify-content: center;
+    align-items: center;
+}
+
+.border-bottom {
+    margin-bottom: 20px;
+}
+
+.quantity-button {
+    border: 1px solid #ced4da; /* 테두리 추가 */
+    border-radius: 5px; /* 모서리를 둥글게 */
+}
+
+.quantity-input {
+    max-width: 55px;
+    max-height: 25px;
+    text-align: left; /* 텍스트 가운데 정렬 */
+}
+
+.input-group {
+    display: flex;
+    justify-content: center;
+    margin-left: 0;
+    padding-right: 10px;
+}
+
+.me-2 {
+    margin-left: 10px;
+}
+
+.form-check {
+    display: flex;
+}
+
+.search-condition {
+    border-right: 1px solid #dee2e6; /* 오른쪽 구분선 추가 */
+    padding-right: 15px; /* 오른쪽 패딩 추가 */
+}
+
+.search-condition h5 {
+    margin-bottom: 15px; /* 제목과 아래 간격 추가 */
+}
+
+.custom-checkbox {
+    display: flex;
+    flex-direction: column;
+    padding-top: 10px;
+}
+
+.form-check-label {
+    margin-bottom: 5px;
+}
+
+body {
+    min-height: 100vh;
+    min-height: -webkit-fill-available;
+}
+
+html {
+    height: -webkit-fill-available;
+}
+
+main {
+    height: 100vh;
+    height: -webkit-fill-available;
+    max-height: 100vh;
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+.dropdown-toggle {
+    outline: 0;
+}
+
+.btn-toggle {
+    padding: .25rem .5rem;
+    font-weight: 600;
+    color: var(--bs-emphasis-color);
+    background-color: transparent;
+}
+
+.btn-toggle:hover,
+.btn-toggle:focus {
+    color: rgba(var(--bs-emphasis-color-rgb), .85);
+    background-color: var(--bs-tertiary-bg);
+}
+
+.btn-toggle::before {
+    width: 1.25em;
+    line-height: 0;
+    content: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='rgba%280,0,0,.5%29' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M5 14l6-6-6-6'/%3e%3c/svg%3e");
+    transition: transform .35s ease;
+    transform-origin: .5em 50%;
+}
+
+d
+[data-bs-theme="dark"] .btn-toggle::before {
+    content: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='rgba%28255,255,255,.5%29' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M5 14l6-6-6-6'/%3e%3c/svg%3e");
+}
+
+.btn-toggle[aria-expanded="true"] {
+    color: rgba(var(--bs-emphasis-color-rgb), .85);
+}
+
+.btn-toggle[aria-expanded="true"]::before {
+    transform: rotate(90deg);
+}
+
+.btn-toggle-nav a {
+    padding: .1875rem .5rem;
+    margin-top: .125rem;
+    margin-left: 1.25rem;
+}
+
+.btn-toggle-nav a:hover,
+.btn-toggle-nav a:focus {
+    background-color: var(--bs-tertiary-bg);
+}
+
+.scrollarea {
+    overflow-y: auto;
+}
+
+.bd-placeholder-img {
+    font-size: 1.125rem;
+    text-anchor: middle;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+}
+
+@media (min-width: 768px) {
+    .bd-placeholder-img-lg {
+        font-size: 3.5rem;
+    }
+}
+
+.b-example-divider {
+    width: 100%;
+    height: 3rem;
+    background-color: rgba(0, 0, 0, .1);
+    border: solid rgba(0, 0, 0, .15);
+    border-width: 1px 0;
+    box-shadow: inset 0 .5em 1.5em rgba(0, 0, 0, .1), inset 0 .125em .5em rgba(0, 0, 0, .15);
+}
+
+.b-example-vr {
+    flex-shrink: 0;
+    width: 1.5rem;
+    height: 100vh;
+}
+
+.bi {
+    vertical-align: -.125em;
+    fill: currentColor;
+}
+
+.nav-scroller {
+    position: relative;
+    z-index: 2;
+    height: 2.75rem;
+    overflow-y: hidden;
+}
+
+.nav-scroller .nav {
+    display: flex;
+    flex-wrap: nowrap;
+    padding-bottom: 1rem;
+    margin-top: -1px;
+    overflow-x: auto;
+    text-align: center;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+}
+
+.btn-bd-primary {
+    --bd-violet-bg: #712cf9;
+    --bd-violet-rgb: 112.520718, 44.062154, 249.437846;
+
+    --bs-btn-font-weight: 600;
+    --bs-btn-color: var(--bs-white);
+    --bs-btn-bg: var(--bd-violet-bg);
+    --bs-btn-border-color: var(--bd-violet-bg);
+    --bs-btn-hover-color: var(--bs-white);
+    --bs-btn-hover-bg: #6528e0;
+    --bs-btn-hover-border-color: #6528e0;
+    --bs-btn-focus-shadow-rgb: var(--bd-violet-rgb);
+    --bs-btn-active-color: var(--bs-btn-hover-color);
+    --bs-btn-active-bg: #5a23c8;
+    --bs-btn-active-border-color: #5a23c8;
+}
+
+.bd-mode-toggle {
+    z-index: 1500;
+}
+
+.bd-mode-toggle .dropdown-menu .active .bi {
+    display: block !important;
+}

--- a/src/main/resources/static/js/page/category/categorybooks.js
+++ b/src/main/resources/static/js/page/category/categorybooks.js
@@ -1,30 +1,14 @@
+/* global bootstrap: false */
+(() => {
+    'use strict'
+    const tooltipTriggerList = Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+    tooltipTriggerList.forEach(tooltipTriggerEl => {
+        new bootstrap.Tooltip(tooltipTriggerEl)
+    })
+})()
+
 document.addEventListener('DOMContentLoaded', function () {
     let queryParams = new URLSearchParams(window.location.search);
-    let searchCondition = queryParams.get('search');
-    let checkboxes = document.querySelectorAll('.search-check');
-    checkboxes.forEach(function (checkbox) {
-        if (searchCondition === checkbox.id) {
-            checkbox.checked = true;
-        }
-        // 체크박스 체크했을 때
-        checkbox.addEventListener('change', function (event) {
-            const keyword = queryParams.get('keyword');
-            let newUrl = window.location.pathname + '?keyword=' + keyword;
-            // 체크했다면 검색 조건 붙여서 요청
-            if (event.target.checked) {
-                // 다른 박스 체크 해제
-                let searchCondition = event.target.id;
-                newUrl += '&search=' + searchCondition;
-                checkboxes.forEach(function (box) {
-                    if (box !== event.target) {
-                        box.checked = false;
-                    }
-                });
-            }
-
-            window.location.href = newUrl;
-        });
-    });
 
     // 수량 감소 버튼 클릭
     document.querySelectorAll('.quantity-decrease').forEach(button => {

--- a/src/main/resources/static/js/page/category/categorybooks.js
+++ b/src/main/resources/static/js/page/category/categorybooks.js
@@ -1,0 +1,125 @@
+document.addEventListener('DOMContentLoaded', function () {
+    let queryParams = new URLSearchParams(window.location.search);
+    let searchCondition = queryParams.get('search');
+    let checkboxes = document.querySelectorAll('.search-check');
+    checkboxes.forEach(function (checkbox) {
+        if (searchCondition === checkbox.id) {
+            checkbox.checked = true;
+        }
+        // 체크박스 체크했을 때
+        checkbox.addEventListener('change', function (event) {
+            const keyword = queryParams.get('keyword');
+            let newUrl = window.location.pathname + '?keyword=' + keyword;
+            // 체크했다면 검색 조건 붙여서 요청
+            if (event.target.checked) {
+                // 다른 박스 체크 해제
+                let searchCondition = event.target.id;
+                newUrl += '&search=' + searchCondition;
+                checkboxes.forEach(function (box) {
+                    if (box !== event.target) {
+                        box.checked = false;
+                    }
+                });
+            }
+
+            window.location.href = newUrl;
+        });
+    });
+
+    // 수량 감소 버튼 클릭
+    document.querySelectorAll('.quantity-decrease').forEach(button => {
+        button.addEventListener('click', function () {
+            let quantityInput = button.parentElement.querySelector('.quantity-input');
+            let currentQuantity = parseInt(quantityInput.value);
+            if (isNaN(currentQuantity)) {
+                currentQuantity = 1; // currentValue가 비어있거나 NaN인 경우 1로 설정
+            } else if (currentQuantity > 1) {
+                currentQuantity -= 1;
+            }
+            quantityInput.value = currentQuantity;
+        });
+    });
+
+    // 수량 증가 버튼 클릭
+    document.querySelectorAll('.quantity-increase').forEach(button => {
+        button.addEventListener('click', function () {
+            let quantityInput = button.parentElement.querySelector('.quantity-input');
+            let currentQuantity = parseInt(quantityInput.value);
+            if (isNaN(currentQuantity)) {
+                currentQuantity = 1;
+            } else {
+                currentQuantity += 1;
+                if (currentQuantity > 99) {
+                    currentQuantity = 99;
+                }
+            }
+            quantityInput.value = currentQuantity;
+        });
+    });
+
+    // 수량 입력 필드의 값 변경
+    document.querySelectorAll('.quantity-input').forEach(input => {
+        // 입력 값이 바뀔 때
+        input.addEventListener('input', function () {
+            let currentValue = parseInt(this.value, 10);
+            if (!isNaN(currentValue)) {
+                currentValue = Math.max(1, currentValue);
+                currentValue = Math.min(99, currentValue); // 최대값 99로 제한
+                this.value = currentValue;
+            }
+        });
+        // 입력 값 포커스가 해제될 때
+        input.addEventListener('blur', function () {
+            let currentValue = parseInt(this.value, 10);
+            if (isNaN(currentValue)) {
+                currentValue = 1; // currentValue가 비어있거나 NaN인 경우 0으로 설정
+            }
+            this.value = currentValue;
+        });
+    });
+
+    // 전체 선택
+    let selectAllButton = document.querySelector('.select-all');
+    let bookCheckboxes = document.querySelectorAll('.book-checkbox');
+
+    selectAllButton.addEventListener('click', function () {
+        let allChecked = true;
+        bookCheckboxes.forEach(function (checkbox) {
+            if (!checkbox.checked) {
+                allChecked = false;
+            }
+        });
+
+        bookCheckboxes.forEach(function (checkbox) {
+            checkbox.checked = !allChecked;
+        });
+    });
+
+    // 검색 결과 정렬
+    document.querySelectorAll('.sort-condition').forEach(condition => {
+        condition.addEventListener('click', function () {
+            let sortCondition = this.id.trim();
+            let currentUrl = new URL(window.location.href);
+            currentUrl.searchParams.delete("page");
+            currentUrl.searchParams.set('sorted', sortCondition);
+            window.location.href = currentUrl.toString();
+        });
+    });
+
+    // 페이지 크기 선택
+    let pageSizeParam = new URLSearchParams(window.location.search).get('size');
+    let pageSizeSelect = document.querySelector('.page-size');
+    if (!pageSizeParam) {
+        pageSizeSelect.value = "5";
+    } else {
+        pageSizeSelect.value = pageSizeParam;
+    }
+    pageSizeSelect.addEventListener('change', function () {
+        let selectedPageSize = this.value;
+        let currentUrl = new URL(window.location.href);
+        currentUrl.searchParams.delete("sorted");
+        currentUrl.searchParams.delete("page");
+        currentUrl.searchParams.set('size', selectedPageSize);
+        window.location.replace(currentUrl.toString());
+    });
+});

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -118,7 +118,10 @@
 
                     <ul class="navbar-nav menu-list list-unstyled d-flex gap-md-3 mb-0">
                         <li class="nav-item">
-                            <a href="index.html" class="nav-link active">베스트</a>
+                            <a href="" class="nav-link active">카테고리</a>
+                        </li>
+                        <li class="nav-item">
+                            <a href="index.html" class="nav-link">베스트</a>
                         </li>
                         <li class="nav-item">
                             <a href="shop.html" class="nav-link">신상품</a>

--- a/src/main/resources/templates/page/book/bookdetail.html
+++ b/src/main/resources/templates/page/book/bookdetail.html
@@ -82,7 +82,7 @@
                             <dd class="col-9" th:if="${bookDetail.getPointRate().getEarnType() == 'RATE'}"
                                 th:text="|${bookDetail.getPointRate().getEarnPoint()}%|"></dd>
 
-                            <dd class="col-9" th:unless="${bookDetail.getPointRate().getEarnType() == 'RATE'}"
+                            <dd class="col-9" th:if="${bookDetail.getPointRate().getEarnType() == 'COST'}"
                                 th:text="|${bookDetail.getPointRate().getEarnPoint()}포인트|"></dd>
                         </div>
 

--- a/src/main/resources/templates/page/book/bookdetail.html
+++ b/src/main/resources/templates/page/book/bookdetail.html
@@ -12,8 +12,6 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.11.2/css/all.css"/>
     <!-- Google Fonts Roboto -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"/>
-    <!-- MDB -->
-    <link rel="stylesheet" href="css/mdb.min.css"/>
 </head>
 
 <!-- CSS -->
@@ -22,7 +20,7 @@
 </th:block>
 <!-- JS -->
 <th:block layout:fragment="script">
-    <script th:src="@{http://code.jquery.com/jquery-latest.js}"></script>
+    <script th:src="@{https://code.jquery.com/jquery-latest.js}"></script>
     <script th:src="@{/js/page/book/bookdetail.js}"></script>
 </th:block>
 

--- a/src/main/resources/templates/page/category/categorybooks.html
+++ b/src/main/resources/templates/page/category/categorybooks.html
@@ -79,53 +79,19 @@
         <!-- 사이드바 -->
         <div class="col-md-2 search-condition">
             <h5>상세 카테고리</h5>
-            <div class="form-check flex-shrink-0 p-3" style="margin-left: 0; padding-left: 0 !important;">
+            <div class="form-check flex-shrink-0 p-3">
+                <ul th:fragment="fragment_node(category)"
+                    th:unless="${#lists.isEmpty(category.children)}">
+                    <li th:each="child : ${category.children}" th:inline="text">
+                        <a class="link-body-emphasis d-inline-flex text-decoration-none rounded"
+                           th:text="${child.name}"
+                           th:href="@{/category/{categoryId}(categoryId=${child.id})}">
+                        </a>
+                        <ul th:replace="this::fragment_node(${child})"></ul>
+                    </li>
+                </ul>
 
-                <th:block th:fragment="fragment_node(category)"
-                          th:unless="${#lists.isEmpty(category.getChildren())}">
-
-                    <ul class="list-unstyled ps-0">
-                        <li class="d-inline-flex text-decoration-none rounded"
-                            th:each="child : ${category.getChildren()}" th:inline="text">
-
-                            <th:block th:if="${#lists.size(category.getChildren()) > 0}">
-                                <button class="btn btn-toggle d-inline-flex align-items-center rounded border-0 collapsed"
-                                        data-bs-toggle="collapse" data-bs-target="#home-collapse" aria-expanded="false"
-                                        style="margin-left: 0; padding-left: 0 !important;"
-                                        th:text="${child.getName()}">
-                                </button>
-
-                                <div class="collapse" id="home-collapse"
-                                     style="margin-left: 0; padding-left: 0 !important;">
-                                    <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
-                                        <li>
-                                            <a th:href="@{/category/{categoryId}(categoryId=${category.getId()})}"
-                                               class="link-body-emphasis d-inline-flex text-decoration-none rounded">
-                                                <th:block th:replace="this::fragment_node(${child})"></th:block>
-                                            </a>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </th:block>
-
-                            <th:block th:if="${#lists.size(category.getChildren()) eq 0}">
-                                <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
-                                    <li>
-                                        <a th:href="@{/category/{categoryId}(categoryId=${category.getId()})}"
-                                           class="link-body-emphasis d-inline-flex text-decoration-none rounded">
-                                            [[${child.getName()}]]
-                                            <th:block th:replace="this::fragment_node(${child})"></th:block>
-                                        </a>
-                                    </li>
-                                </ul>
-                            </th:block>
-
-                        </li>
-                    </ul>
-
-                </th:block>
-
-
+                <!-- 하위 카테고리 없는 경우 -->
                 <ul class="mb-1" th:if="${#lists.size(category.getChildren()) eq 0}">
                     <li class="d-inline-flex text-decoration-none rounded">
                         하위 카테고리 없음
@@ -149,15 +115,20 @@
                             </div>
                             <!-- 이미지 -->
                             <div class="col-md-3">
-                                <img th:src="${book.thumbnail != null} ? ${book.thumbnail} : '/images/no-image.jpg'"
-                                     class="card-img-top img-fluid rounded-start"
-                                     alt="...">
+                                <a th:href="@{/book/detail/{bookId}(bookId=${book.getId()})}">
+                                    <img th:src="${book.thumbnail != null} ? ${book.thumbnail} : '/images/no-image.jpg'"
+                                         class="card-img-top img-fluid rounded-start"
+                                         alt="...">
+                                </a>
                             </div>
                             <!-- 도서 정보 -->
                             <div class="col-md-6">
                                 <div class="card-body">
-                                    <h5 class="card-title" th:text="${book.title}">오늘부터 나를 고쳐 쓰기로 했다 - 다시 태어나지 않고도 삶을
-                                        바꾸는 매일의 작은 습관들</h5>
+                                    <a th:href="@{/book/detail/{bookId}(bookId=${book.getId()})}">
+                                        <h5 class="card-title" th:text="${book.title}">
+                                            오늘부터 나를 고쳐 쓰기로 했다 - 다시 태어나지 않고도 삶을 바꾸는 매일의 작은 습관들
+                                        </h5>
+                                    </a>
                                     <p class="card-text">
                                         <span th:each="author : ${book.author}">
                                             <span th:text="${author.name}"></span>
@@ -207,7 +178,7 @@
                 <ul class="pagination justify-content-center">
                     <li class="page-item" th:classappend="${currentPage == 0} ? 'disabled'">
                         <a class="page-link"
-                           th:href="@{/category(categoryId=${keyword}, page=${currentPage - 1}, size=${pageSize}, search=${search}, sorted=${sorted})}"
+                           th:href="@{/category/{categoryId}(categoryId=${category.getId()}, page=${currentPage - 1}, size=${pageSize}, sorted=${sorted})}"
                            aria-label="Previous">
                             <span aria-hidden="true">&laquo;</span>
                         </a>
@@ -215,12 +186,12 @@
                     <li class="page-item" th:each="pageNum : ${#numbers.sequence(0, totalPages - 1)}"
                         th:classappend="${pageNum == currentPage} ? 'active'">
                         <a class="page-link"
-                           th:href="@{/category(categoryId=${keyword}, page=${pageNum}, size=${pageSize}, search=${search}, sorted=${sorted})}"
+                           th:href="@{/category/{categoryId}(categoryId=${category.getId()}, page=${currentPage - 1}, size=${pageSize}, sorted=${sorted})}"
                            th:text="${pageNum + 1}"></a>
                     </li>
                     <li class="page-item" th:classappend="${currentPage + 1 == totalPages} ? 'disabled'">
                         <a class="page-link"
-                           th:href="@{/category(categoryId=${keyword}, page=${currentPage + 1}, size=${pageSize}, search=${search}, sorted=${sorted})}"
+                           th:href="@{/category/{categoryId}(categoryId=${category.getId()}, page=${currentPage - 1}, size=${pageSize}, sorted=${sorted})}"
                            aria-label="Next">
                             <span aria-hidden="true">&raquo;</span>
                         </a>

--- a/src/main/resources/templates/page/category/categorybooks.html
+++ b/src/main/resources/templates/page/category/categorybooks.html
@@ -2,14 +2,13 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{layouts/default_layout}">
+      layout:decorate="~{layouts/default_layout}"
+      lang="ko">
 
-<head>
-    <meta charset="UTF-8">
-</head>
 <!-- 메인 페이지 고유 CSS 추가 -->
 <th:block layout:fragment="css">
-    <link rel="stylesheet" th:href="@{/css/page/search.css}">
+    <link rel="stylesheet" th:href="@{/css/page/category/categorybooks.css}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3">
 </th:block>
 <!-- 메인 페이지 고유 스크립트 추가 -->
 <th:block layout:fragment="script">
@@ -21,8 +20,15 @@
     <div class="row">
         <!-- 검색 결과 건수 -->
         <div class="col-md-12 mb-3 result">
-            <p><span class="search-result" th:text="${keyword}">검색어</span>에 대한 결과가
-                <span class="search-result" th:text="${totalItems}">3</span>건 있습니다.</p>
+            <p th:unless="${category eq null}">
+                <span class="search-result" th:text="${category.getName()}">카테고리 이름</span>에 속한 도서가
+                <span class="search-result" th:text="${totalItems}">3</span>건 있습니다.
+            </p>
+
+            <p th:if="${category eq null}">
+                <span class="search-result">ERROR</span>에 속한 도서가
+                <span class="search-result" th:text="${totalItems}">3</span>건 있습니다.
+            </p>
         </div>
     </div>
 
@@ -73,11 +79,59 @@
         <!-- 사이드바 -->
         <div class="col-md-2 search-condition">
             <h5>상세 카테고리</h5>
-            <div class="form-check">
-                <input class="custom-checkbox form-check-input search-check"
-                       style="justify-content: center; border: 1px solid rgba(62, 65, 68, 0.52);margin-top: 9px"
-                       type="radio" id="book_title">
-                <label class="form-check-label" for="book_title">도서명</label>
+            <div class="form-check flex-shrink-0 p-3" style="margin-left: 0; padding-left: 0 !important;">
+
+                <th:block th:fragment="fragment_node(category)"
+                          th:unless="${#lists.isEmpty(category.getChildren())}">
+
+                    <ul class="list-unstyled ps-0">
+                        <li class="d-inline-flex text-decoration-none rounded"
+                            th:each="child : ${category.getChildren()}" th:inline="text">
+
+                            <th:block th:if="${#lists.size(category.getChildren()) > 0}">
+                                <button class="btn btn-toggle d-inline-flex align-items-center rounded border-0 collapsed"
+                                        data-bs-toggle="collapse" data-bs-target="#home-collapse" aria-expanded="false"
+                                        style="margin-left: 0; padding-left: 0 !important;"
+                                        th:text="${child.getName()}">
+                                </button>
+
+                                <div class="collapse" id="home-collapse"
+                                     style="margin-left: 0; padding-left: 0 !important;">
+                                    <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
+                                        <li>
+                                            <a th:href="@{/category/{categoryId}(categoryId=${category.getId()})}"
+                                               class="link-body-emphasis d-inline-flex text-decoration-none rounded">
+                                                <th:block th:replace="this::fragment_node(${child})"></th:block>
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </th:block>
+
+                            <th:block th:if="${#lists.size(category.getChildren()) eq 0}">
+                                <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
+                                    <li>
+                                        <a th:href="@{/category/{categoryId}(categoryId=${category.getId()})}"
+                                           class="link-body-emphasis d-inline-flex text-decoration-none rounded">
+                                            [[${child.getName()}]]
+                                            <th:block th:replace="this::fragment_node(${child})"></th:block>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </th:block>
+
+                        </li>
+                    </ul>
+
+                </th:block>
+
+
+                <ul class="mb-1" th:if="${#lists.size(category.getChildren()) eq 0}">
+                    <li class="d-inline-flex text-decoration-none rounded">
+                        하위 카테고리 없음
+                    </li>
+                </ul>
+
             </div>
         </div>
 

--- a/src/main/resources/templates/page/category/categorybooks.html
+++ b/src/main/resources/templates/page/category/categorybooks.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/default_layout}">
+
+<head>
+    <meta charset="UTF-8">
+</head>
+<!-- 메인 페이지 고유 CSS 추가 -->
+<th:block layout:fragment="css">
+    <link rel="stylesheet" th:href="@{/css/page/search.css}">
+</th:block>
+<!-- 메인 페이지 고유 스크립트 추가 -->
+<th:block layout:fragment="script">
+    <script th:src="@{/js/page/category/categorybooks.js}"></script>
+</th:block>
+
+<!-- Content -->
+<div layout:fragment="content" class="container my-5">
+    <div class="row">
+        <!-- 검색 결과 건수 -->
+        <div class="col-md-12 mb-3 result">
+            <p><span class="search-result" th:text="${keyword}">검색어</span>에 대한 결과가
+                <span class="search-result" th:text="${totalItems}">3</span>건 있습니다.</p>
+        </div>
+    </div>
+
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+        <div class="container-fluid">
+            <!-- Buttons added to the left of the form -->
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+                    data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false"
+                    aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNavDropdown">
+                <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                    <li class="nav-item">
+                        <a class="nav-link sort-condition" id="NONE" href="#">정확도순</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link sort-condition" id="POPULAR" href="#">인기도순</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link sort-condition" id="LATEST" href="#">신상품순</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link sort-condition" id="LOWEST_PRICE" href="#">낮은가격순</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link sort-condition" id="HIGHEST_PRICE" href="#">높은가격순</a>
+                    </li>
+                </ul>
+                <div class="d-flex">
+                    <button type="button" class="btn btn-outline-secondary select-all">전체선택</button>
+                    <button type="button" class="btn btn-outline-secondary">장바구니</button>
+                    <button type="button" class="btn btn-outline-secondary">바로구매</button>
+                    <button type="button" class="btn btn-outline-secondary">좋아요</button>
+                </div>
+                <form class="d-flex">
+                    <select class="form-select me-2 page-size" aria-label="page size select">
+                        <option value="5">5개씩 보기</option>
+                        <option value="10">10개씩 보기</option>
+                        <option value="20">20개씩 보기</option>
+                    </select>
+                </form>
+            </div>
+        </div>
+    </nav>
+
+    <div class="row">
+        <!-- 사이드바 -->
+        <div class="col-md-2 search-condition">
+            <h5>상세 카테고리</h5>
+            <div class="form-check">
+                <input class="custom-checkbox form-check-input search-check"
+                       style="justify-content: center; border: 1px solid rgba(62, 65, 68, 0.52);margin-top: 9px"
+                       type="radio" id="book_title">
+                <label class="form-check-label" for="book_title">도서명</label>
+            </div>
+        </div>
+
+        <!-- 검색 결과 -->
+        <div class="col-md-10">
+            <div class="row flex-column">
+                <!-- 검색 결과 카드 -->
+                <div class="col-md-12 mb-6 border-bottom" th:each="book : ${books}">
+                    <div class="card">
+                        <!-- 카드 내용 -->
+                        <div class="row g-0">
+                            <div class="col-md-1 custom-checkbox">
+                                <label th:for="${'bookCheckbox' + bookStat.index}"></label>
+                                <input type="checkbox" class="book-checkbox" th:id="${'bookCheckbox' + bookStat.index}">
+                            </div>
+                            <!-- 이미지 -->
+                            <div class="col-md-3">
+                                <img th:src="${book.thumbnail != null} ? ${book.thumbnail} : '/images/no-image.jpg'"
+                                     class="card-img-top img-fluid rounded-start"
+                                     alt="...">
+                            </div>
+                            <!-- 도서 정보 -->
+                            <div class="col-md-6">
+                                <div class="card-body">
+                                    <h5 class="card-title" th:text="${book.title}">오늘부터 나를 고쳐 쓰기로 했다 - 다시 태어나지 않고도 삶을
+                                        바꾸는 매일의 작은 습관들</h5>
+                                    <p class="card-text">
+                                        <span th:each="author : ${book.author}">
+                                            <span th:text="${author.name}"></span>
+                                            <span th:text="'(' + ${author.role} + ')'"></span>
+                                            <span th:if="${!authorStat.last}">,</span>
+                                        </span>
+                                    </p>
+                                    <p class="card-text"
+                                       th:text="${book.publisherName} + ' · ' + ${#temporals.format(book.pubDate, 'yyyy. MM. dd')}">
+                                        부키 · <span>2024. 04. 01</span>
+                                    </p>
+                                    <p class="card-text"><span class="fw-bold" th:text="${book.discountPrice} + '원'">12,000</span>
+                                        <span class="text-muted original-price"
+                                              th:text="${book.price} + '원'">15,000</span></p>
+                                    <p class="card-text"><span th:text="${book.reviewRating}">4.8</span> /
+                                        <span>리뷰(<span th:text="${book.reviewCount}">123</span>)개</span></p>
+                                </div>
+                            </div>
+                            <div class="col-md-2 quantity-and-buttons">
+                                <div class="row">
+                                    <div class="col-6 col-md-12 quantity-input-group">
+                                        <div class="input-group mb-3">
+                                            <button class="btn btn-outline-secondary quantity-decrease quantity-button"
+                                                    type="button">-
+                                            </button>
+                                            <input type="text" class="form-control quantity-input" placeholder=""
+                                                   id="quantity${bookStat.index}"
+                                                   value=1>
+                                            <button class="btn btn-outline-secondary quantity-increase quantity-button"
+                                                    type="button">+
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="col-6 col-md-12 btn-div">
+                                        <button type="button" class="btn btn-primary custom-btn custom-primary">구매하기
+                                        </button>
+                                        <button type="button" class="btn btn-success custom-btn">장바구니</button>
+                                        <button type="button" class="btn btn-secondary custom-btn">좋아요</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <nav aria-label="Page navigation" th:if="${totalItems > 0}">
+                <ul class="pagination justify-content-center">
+                    <li class="page-item" th:classappend="${currentPage == 0} ? 'disabled'">
+                        <a class="page-link"
+                           th:href="@{/category(categoryId=${keyword}, page=${currentPage - 1}, size=${pageSize}, search=${search}, sorted=${sorted})}"
+                           aria-label="Previous">
+                            <span aria-hidden="true">&laquo;</span>
+                        </a>
+                    </li>
+                    <li class="page-item" th:each="pageNum : ${#numbers.sequence(0, totalPages - 1)}"
+                        th:classappend="${pageNum == currentPage} ? 'active'">
+                        <a class="page-link"
+                           th:href="@{/category(categoryId=${keyword}, page=${pageNum}, size=${pageSize}, search=${search}, sorted=${sorted})}"
+                           th:text="${pageNum + 1}"></a>
+                    </li>
+                    <li class="page-item" th:classappend="${currentPage + 1 == totalPages} ? 'disabled'">
+                        <a class="page-link"
+                           th:href="@{/category(categoryId=${keyword}, page=${currentPage + 1}, size=${pageSize}, search=${search}, sorted=${sorted})}"
+                           aria-label="Next">
+                            <span aria-hidden="true">&raquo;</span>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+
+        </div>
+    </div>
+</div>
+</html>

--- a/src/main/resources/templates/page/category/categorybooks.html
+++ b/src/main/resources/templates/page/category/categorybooks.html
@@ -186,12 +186,12 @@
                     <li class="page-item" th:each="pageNum : ${#numbers.sequence(0, totalPages - 1)}"
                         th:classappend="${pageNum == currentPage} ? 'active'">
                         <a class="page-link"
-                           th:href="@{/category/{categoryId}(categoryId=${category.getId()}, page=${currentPage - 1}, size=${pageSize}, sorted=${sorted})}"
+                           th:href="@{/category/{categoryId}(categoryId=${category.getId()}, page=${pageNum}, size=${pageSize}, sorted=${sorted})}"
                            th:text="${pageNum + 1}"></a>
                     </li>
                     <li class="page-item" th:classappend="${currentPage + 1 == totalPages} ? 'disabled'">
                         <a class="page-link"
-                           th:href="@{/category/{categoryId}(categoryId=${category.getId()}, page=${currentPage - 1}, size=${pageSize}, sorted=${sorted})}"
+                           th:href="@{/category/{categoryId}(categoryId=${category.getId()}, page=${currentPage + 1}, size=${pageSize}, sorted=${sorted})}"
                            aria-label="Next">
                             <span aria-hidden="true">&raquo;</span>
                         </a>


### PR DESCRIPTION
# 설명
- 카테고리 선택에 따른 pageable 적용된 도서 목록

# 작업내용
- html 추가
- 이미지 혹은 제목 클릭 시 상세정보 페이지로 이동
- pagination 적용 
- 변동 page size 적용(검색 페이지와 동일)
- 정렬 방식 변경 적용(검색 페이지와 동일)
- 추가: 책 상세 페이지 포인트 적립률 출력 방식 변경

페이지 예시

![localhost_8020_category_1](https://github.com/nhnacademy-be5-bom/bookbom-front/assets/48512751/6b566ba4-8a69-4c2d-8640-ccc5a1d4ad26)



 

