### PR TITLE
[feat] 에러 페이지 구현

### DIFF
--- a/src/main/java/shop/bookbom/front/common/exception/ErrorCode.java
+++ b/src/main/java/shop/bookbom/front/common/exception/ErrorCode.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
     // common
-    COMMON_SYSTEM_ERROR(500, "시스템 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    COMMON_SYSTEM_ERROR(500, "시스템 오류가 발생했습니다. 관리자에게 문의 주세요."),
     COMMON_INVALID_PARAMETER(400, "요청한 값이 올바르지 않습니다."),
     COMMON_ENTITY_NOT_FOUND(400, "존재하지 않는 엔티티입니다."),
     COMMON_ILLEGAL_STATUS(400, "잘못된 상태값입니다."),

--- a/src/main/java/shop/bookbom/front/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/shop/bookbom/front/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package shop.bookbom.front.common.exception;
+
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(BaseException.class)
+    public String handleBaseException(BaseException e, Model model) {
+        model.addAttribute("errorCode", e.getErrorCode());
+        model.addAttribute("message", e.getMessage());
+        return "page/error";
+    }
+}

--- a/src/main/java/shop/bookbom/front/common/exception/RestTemplateException.java
+++ b/src/main/java/shop/bookbom/front/common/exception/RestTemplateException.java
@@ -1,0 +1,7 @@
+package shop.bookbom.front.common.exception;
+
+public class RestTemplateException extends BaseException {
+    public RestTemplateException() {
+        super(ErrorCode.COMMON_SYSTEM_ERROR);
+    }
+}

--- a/src/main/java/shop/bookbom/front/domain/cart/adapter/impl/CartAdapterImpl.java
+++ b/src/main/java/shop/bookbom/front/domain/cart/adapter/impl/CartAdapterImpl.java
@@ -14,6 +14,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import shop.bookbom.front.common.CommonListResponse;
 import shop.bookbom.front.common.CommonResponse;
+import shop.bookbom.front.common.exception.RestTemplateException;
 import shop.bookbom.front.domain.cart.adapter.CartAdapter;
 import shop.bookbom.front.domain.cart.dto.request.CartAddRequest;
 import shop.bookbom.front.domain.cart.dto.request.CartUpdateRequest;
@@ -56,8 +57,7 @@ public class CartAdapterImpl implements CartAdapter {
                         CART_ITEM_IDS_RESPONSE)
                 .getBody();
         if (response == null || !response.getHeader().isSuccessful()) {
-            // todo 예외처리
-            throw new RuntimeException();
+            throw new RestTemplateException();
         }
         return Objects.requireNonNull(response).getResult();
     }
@@ -80,8 +80,7 @@ public class CartAdapterImpl implements CartAdapter {
                 .getBody();
 
         if (response == null || !response.getHeader().isSuccessful()) {
-            // todo 예외처리
-            throw new RuntimeException();
+            throw new RestTemplateException();
         }
         return response.getResult();
     }
@@ -103,8 +102,7 @@ public class CartAdapterImpl implements CartAdapter {
                 .getBody();
 
         if (response == null || !response.getHeader().isSuccessful()) {
-            // todo 예외처리
-            throw new RuntimeException();
+            throw new RestTemplateException();
         }
         return response.getResult();
     }
@@ -125,8 +123,7 @@ public class CartAdapterImpl implements CartAdapter {
                         COMMON_RESPONSE)
                 .getBody();
         if (response == null || !response.getHeader().isSuccessful()) {
-            // todo 예외처리
-            throw new RuntimeException();
+            throw new RestTemplateException();
         }
     }
 }

--- a/src/main/java/shop/bookbom/front/domain/member/adapter/MemberAdapterImpl.java
+++ b/src/main/java/shop/bookbom/front/domain/member/adapter/MemberAdapterImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import shop.bookbom.front.common.CommonResponse;
+import shop.bookbom.front.common.exception.RestTemplateException;
 import shop.bookbom.front.domain.member.dto.response.MemberInfoResponse;
 
 @Component
@@ -40,8 +41,7 @@ public class MemberAdapterImpl implements MemberAdapter {
                 requestEntity,
                 MEMBER_INFO).getBody();
         if (response == null || !response.getHeader().isSuccessful()) {
-            // todo 예외처리
-            throw new RuntimeException();
+            throw new RestTemplateException();
         }
         return response.getResult();
     }

--- a/src/main/java/shop/bookbom/front/domain/order/adapter/OrderAdapterImpl.java
+++ b/src/main/java/shop/bookbom/front/domain/order/adapter/OrderAdapterImpl.java
@@ -16,6 +16,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import shop.bookbom.front.common.CommonPage;
 import shop.bookbom.front.common.CommonResponse;
+import shop.bookbom.front.common.exception.RestTemplateException;
 import shop.bookbom.front.domain.order.dto.request.BeforeOrderRequestList;
 import shop.bookbom.front.domain.order.dto.request.OpenOrderRequest;
 import shop.bookbom.front.domain.order.dto.request.OrderStatusUpdateRequest;
@@ -154,8 +155,7 @@ public class OrderAdapterImpl implements OrderAdapter {
         CommonResponse<OrderDetailResponse> response = restTemplate.exchange(url, HttpMethod.GET, requestEntity,
                 ORDER_DETAIL_RESPONSE).getBody();
         if (response == null || response.getHeader().isSuccessful()) {
-            // todo 예외처리
-            throw new RuntimeException();
+            throw new RestTemplateException();
         }
         return response.getResult();
     }

--- a/src/main/java/shop/bookbom/front/domain/pointhistory/adapter/impl/PointHistoryAdapterImpl.java
+++ b/src/main/java/shop/bookbom/front/domain/pointhistory/adapter/impl/PointHistoryAdapterImpl.java
@@ -15,6 +15,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import shop.bookbom.front.common.CommonPage;
 import shop.bookbom.front.common.CommonResponse;
+import shop.bookbom.front.common.exception.RestTemplateException;
 import shop.bookbom.front.domain.pointhistory.adapter.PointHistoryAdapter;
 import shop.bookbom.front.domain.pointhistory.dto.PointHistoryResponse;
 
@@ -49,8 +50,7 @@ public class PointHistoryAdapterImpl implements PointHistoryAdapter {
         CommonResponse<CommonPage<PointHistoryResponse>> response =
                 restTemplate.exchange(url, HttpMethod.GET, requestEntity, POINT_HISTORY_RESPONSE).getBody();
         if (response == null || !response.getHeader().isSuccessful()) {
-            // todo 예외처리
-            throw new RuntimeException();
+            throw new RestTemplateException();
         }
         return Objects.requireNonNull(response).getResult();
     }

--- a/src/main/java/shop/bookbom/front/domain/pointrate/adapter/impl/PointRateAdapterImpl.java
+++ b/src/main/java/shop/bookbom/front/domain/pointrate/adapter/impl/PointRateAdapterImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import shop.bookbom.front.common.CommonResponse;
+import shop.bookbom.front.common.exception.RestTemplateException;
 import shop.bookbom.front.domain.pointrate.adapter.PointRateAdapter;
 import shop.bookbom.front.domain.pointrate.dto.PointRate;
 import shop.bookbom.front.domain.pointrate.dto.request.PointRateUpdateRequest;
@@ -42,8 +43,7 @@ public class PointRateAdapterImpl implements PointRateAdapter {
         CommonResponse<List<PointRate>> response =
                 restTemplate.exchange(url, HttpMethod.GET, requestEntity, POINT_RATE_LIST_RESPONSE).getBody();
         if (response == null || !response.getHeader().isSuccessful()) {
-            // todo 예외처리
-            throw new RuntimeException();
+            throw new RestTemplateException();
         }
         return response.getResult();
     }
@@ -62,8 +62,7 @@ public class PointRateAdapterImpl implements PointRateAdapter {
                 restTemplate.exchange(url, HttpMethod.PUT, requestEntity, POINT_RATE_RESPONSE).getBody();
 
         if (response == null || !response.getHeader().isSuccessful()) {
-            // todo 예외처리
-            throw new RuntimeException();
+            throw new RestTemplateException();
         }
         return response.getResult();
     }

--- a/src/main/java/shop/bookbom/front/domain/search/adaptor/impl/SearchAdapterImpl.java
+++ b/src/main/java/shop/bookbom/front/domain/search/adaptor/impl/SearchAdapterImpl.java
@@ -15,6 +15,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import shop.bookbom.front.common.CommonPage;
 import shop.bookbom.front.common.CommonResponse;
+import shop.bookbom.front.common.exception.RestTemplateException;
 import shop.bookbom.front.domain.book.dto.response.BookSearchResponse;
 import shop.bookbom.front.domain.search.adaptor.SearchAdapter;
 
@@ -49,8 +50,7 @@ public class SearchAdapterImpl implements SearchAdapter {
         CommonResponse<CommonPage<BookSearchResponse>> response =
                 restTemplate.exchange(url, HttpMethod.GET, requestEntity, BOOK_SEARCH_RESPONSE).getBody();
         if (response == null || !response.getHeader().isSuccessful()) {
-            // todo 예외처리
-            throw new RuntimeException();
+            throw new RestTemplateException();
         }
         return Objects.requireNonNull(response).getResult();
     }

--- a/src/main/java/shop/bookbom/front/domain/user/adapter/impl/UserAdapterImpl.java
+++ b/src/main/java/shop/bookbom/front/domain/user/adapter/impl/UserAdapterImpl.java
@@ -15,6 +15,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import shop.bookbom.front.common.CommonPage;
 import shop.bookbom.front.common.CommonResponse;
+import shop.bookbom.front.common.exception.RestTemplateException;
 import shop.bookbom.front.domain.member.dto.request.OrderDateCondition;
 import shop.bookbom.front.domain.order.dto.response.OrderInfoResponse;
 import shop.bookbom.front.domain.user.adapter.UserAdapter;
@@ -51,8 +52,7 @@ public class UserAdapterImpl implements UserAdapter {
                 .getBody();
 
         if (response == null || !response.getHeader().isSuccessful()) {
-            // todo 예외처리
-            throw new RuntimeException();
+            throw new RestTemplateException();
         }
         return Objects.requireNonNull(response).getResult();
     }

--- a/src/main/java/shop/bookbom/front/index/adapter/impl/IndexAdapterImpl.java
+++ b/src/main/java/shop/bookbom/front/index/adapter/impl/IndexAdapterImpl.java
@@ -15,6 +15,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import shop.bookbom.front.common.CommonPage;
 import shop.bookbom.front.common.CommonResponse;
+import shop.bookbom.front.common.exception.RestTemplateException;
 import shop.bookbom.front.domain.book.dto.response.BookSearchResponse;
 import shop.bookbom.front.index.adapter.IndexAdapter;
 
@@ -48,8 +49,7 @@ public class IndexAdapterImpl implements IndexAdapter {
                 restTemplate.exchange(url, HttpMethod.GET, requestEntity, BOOK_PAGE_RESPONSE).getBody();
 
         if (response == null || !response.getHeader().isSuccessful()) {
-            // todo 예외처리
-            throw new RuntimeException();
+            throw new RestTemplateException();
         }
         return Objects.requireNonNull(response).getResult();
     }
@@ -69,8 +69,7 @@ public class IndexAdapterImpl implements IndexAdapter {
         CommonResponse<CommonPage<BookSearchResponse>> response =
                 restTemplate.exchange(url, HttpMethod.GET, requestEntity, BOOK_PAGE_RESPONSE).getBody();
         if (response == null || !response.getHeader().isSuccessful()) {
-            // todo 예외처리
-            throw new RuntimeException();
+            throw new RestTemplateException();
         }
         return Objects.requireNonNull(response).getResult();
     }

--- a/src/main/resources/templates/page/error.html
+++ b/src/main/resources/templates/page/error.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="ko"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <title>책봄</title>
+    <meta content="width=device-width, maximum-scale=1.0, minimum-scale=1, user-scalable=yes,initial-scale=1.0"
+          name="viewport"/>
+    <link rel="stylesheet" th:href="@{/css/fonts/fonts.css}" type="text/css">
+    <link crossorigin="anonymous" integrity="sha384-KK94CHFLLe+nY2dmCWGMq91rCGa5gtU4mk92HdvYe+M/SXH301p5ILy+dN9+nJOZ"
+          rel="stylesheet" th:href="@{/assets/vendor/bootstrap-5.1.3/css/bootstrap.min.css}">
+
+    <link rel="stylesheet" th:href="@{/assets/vendor/bootstrap-5.1.3/css/sb-admin-2.css}">
+    <link rel="stylesheet" th:href="@{/assets/vendor/bootstrap-5.1.3/css/sb-admin-2.min.css}">
+</head>
+<body>
+<div class="container-fluid">
+    <!-- 404 Error Text -->
+    <div class="text-center" style="margin-top: 10%">
+        <div class="error mx-auto" th:data-text="${errorCode.code}" th:text="${errorCode.code}">404</div>
+        <p class="lead text-gray-800 mb-5">에러가 발생했습니다.</p>
+        <p class="lead text-gray-800 mb-5" th:text="${message}">에러가 발생했습니다.</p>
+        <p class="text-gray-500 mb-0" th:text="${errorCode}">It looks like you found a glitch in the matrix...</p>
+        <a href="/">← 메인 페이지로 이동</a>
+    </div>
+</div>
+</body>
+</html>
+
+


### PR DESCRIPTION
# 설명
- 에러 페이지를 구현하였습니다.

# 작업내용
- BaseException 에 대한 ExceptionHandler를 만들어서 에러 페이지로 이동하도록 구현했습니다.
- 에러페이지를 보여주고 싶다면 BaseException을 상속 받는 예외 클래스를 만들고 던지시면 됩니다.
- 클라이언트에게 보여질 에러 메시지이므로, 클라이언트가 이해할 수 있는 예외 메시지여야 합니다.
- 에러 페이지에서는 메인 페이지로 이동할 수 있습니다.
 
![image](https://github.com/nhnacademy-be5-bom/bookbom-front/assets/95916780/694b5e01-6b54-45da-99ae-4b578e91659b)
