### PR TITLE
[feat] 회원 주소록 구현

### DIFF
--- a/src/main/java/shop/bookbom/front/domain/address/adapter/AddressAdapter.java
+++ b/src/main/java/shop/bookbom/front/domain/address/adapter/AddressAdapter.java
@@ -1,0 +1,13 @@
+package shop.bookbom.front.domain.address.adapter;
+
+import java.util.List;
+import shop.bookbom.front.domain.address.dto.AddressResponse;
+
+public interface AddressAdapter {
+    /**
+     * 회원의 주소록을 조회하는 메서드입니다.
+     *
+     * @return 주소록
+     */
+    List<AddressResponse> getAddressBook();
+}

--- a/src/main/java/shop/bookbom/front/domain/address/adapter/AddressAdapter.java
+++ b/src/main/java/shop/bookbom/front/domain/address/adapter/AddressAdapter.java
@@ -2,6 +2,7 @@ package shop.bookbom.front.domain.address.adapter;
 
 import java.util.List;
 import shop.bookbom.front.domain.address.dto.AddressResponse;
+import shop.bookbom.front.domain.address.dto.request.AddressRequest;
 
 public interface AddressAdapter {
     /**
@@ -10,4 +11,11 @@ public interface AddressAdapter {
      * @return 주소록
      */
     List<AddressResponse> getAddressBook();
+
+    /**
+     * 주소를 저장하는 메서드입니다.
+     *
+     * @param request 주소 저장 요청
+     */
+    void saveAddress(AddressRequest request);
 }

--- a/src/main/java/shop/bookbom/front/domain/address/adapter/AddressAdapter.java
+++ b/src/main/java/shop/bookbom/front/domain/address/adapter/AddressAdapter.java
@@ -18,4 +18,17 @@ public interface AddressAdapter {
      * @param request 주소 저장 요청
      */
     void saveAddress(AddressRequest request);
+
+    /**
+     * 기본 주소지로 설정하는 메서드입니다.
+     *
+     * @param id 주소 id
+     */
+    void updateDefaultAddress(Long id);
+
+    /**
+     * 주소를 삭제하는 메서드입니다.
+     * @param id 주소 id
+     */
+    void deleteAddress(Long id);
 }

--- a/src/main/java/shop/bookbom/front/domain/address/adapter/impl/AddressAdapterImpl.java
+++ b/src/main/java/shop/bookbom/front/domain/address/adapter/impl/AddressAdapterImpl.java
@@ -1,0 +1,52 @@
+package shop.bookbom.front.domain.address.adapter.impl;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import shop.bookbom.front.common.CommonListResponse;
+import shop.bookbom.front.common.exception.RestTemplateException;
+import shop.bookbom.front.domain.address.adapter.AddressAdapter;
+import shop.bookbom.front.domain.address.dto.AddressResponse;
+
+@Component
+@RequiredArgsConstructor
+public class AddressAdapterImpl implements AddressAdapter {
+    private static final ParameterizedTypeReference<CommonListResponse<AddressResponse>> ADDRESS_LIST =
+            new ParameterizedTypeReference<>() {
+            };
+    private final RestTemplate restTemplate;
+    @Value("${bookbom.gateway-url}")
+    String gatewayUrl;
+
+    @Override
+    public List<AddressResponse> getAddressBook() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<Void> requestEntity = new HttpEntity<>(httpHeaders);
+
+        String url = UriComponentsBuilder.fromHttpUrl(gatewayUrl + "/shop/users/address")
+                .toUriString();
+
+        CommonListResponse<AddressResponse> response = restTemplate.exchange(
+                        url,
+                        HttpMethod.GET,
+                        requestEntity,
+                        ADDRESS_LIST)
+                .getBody();
+        if (response == null) {
+            throw new RestTemplateException();
+        }
+        if (!response.getHeader().isSuccessful()) {
+            throw new RestTemplateException(response.getHeader().getResultMessage());
+        }
+        return response.getResult();
+    }
+}

--- a/src/main/java/shop/bookbom/front/domain/address/adapter/impl/AddressAdapterImpl.java
+++ b/src/main/java/shop/bookbom/front/domain/address/adapter/impl/AddressAdapterImpl.java
@@ -12,14 +12,19 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import shop.bookbom.front.common.CommonListResponse;
+import shop.bookbom.front.common.CommonResponse;
 import shop.bookbom.front.common.exception.RestTemplateException;
 import shop.bookbom.front.domain.address.adapter.AddressAdapter;
 import shop.bookbom.front.domain.address.dto.AddressResponse;
+import shop.bookbom.front.domain.address.dto.request.AddressRequest;
 
 @Component
 @RequiredArgsConstructor
 public class AddressAdapterImpl implements AddressAdapter {
     private static final ParameterizedTypeReference<CommonListResponse<AddressResponse>> ADDRESS_LIST =
+            new ParameterizedTypeReference<>() {
+            };
+    private static final ParameterizedTypeReference<CommonResponse<Void>> COMMON_RESPONSE =
             new ParameterizedTypeReference<>() {
             };
     private final RestTemplate restTemplate;
@@ -48,5 +53,29 @@ public class AddressAdapterImpl implements AddressAdapter {
             throw new RestTemplateException(response.getHeader().getResultMessage());
         }
         return response.getResult();
+    }
+
+    @Override
+    public void saveAddress(AddressRequest request) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<AddressRequest> requestEntity = new HttpEntity<>(request, httpHeaders);
+
+        String url = UriComponentsBuilder.fromHttpUrl(gatewayUrl + "/shop/users/address")
+                .toUriString();
+
+        CommonResponse<Void> response = restTemplate.exchange(
+                        url,
+                        HttpMethod.POST,
+                        requestEntity,
+                        COMMON_RESPONSE)
+                .getBody();
+        if (response == null) {
+            throw new RestTemplateException();
+        }
+        if (!response.getHeader().isSuccessful()) {
+            throw new RestTemplateException(response.getHeader().getResultMessage());
+        }
     }
 }

--- a/src/main/java/shop/bookbom/front/domain/address/adapter/impl/AddressAdapterImpl.java
+++ b/src/main/java/shop/bookbom/front/domain/address/adapter/impl/AddressAdapterImpl.java
@@ -78,4 +78,52 @@ public class AddressAdapterImpl implements AddressAdapter {
             throw new RestTemplateException(response.getHeader().getResultMessage());
         }
     }
+
+    @Override
+    public void updateDefaultAddress(Long id) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Void> requestEntity = new HttpEntity<>(httpHeaders);
+
+        String url = UriComponentsBuilder.fromHttpUrl(gatewayUrl + "/shop/users/address/default/" + id)
+                .toUriString();
+
+        CommonResponse<Void> response = restTemplate.exchange(
+                        url,
+                        HttpMethod.POST,
+                        requestEntity,
+                        COMMON_RESPONSE)
+                .getBody();
+        if (response == null) {
+            throw new RestTemplateException();
+        }
+        if (!response.getHeader().isSuccessful()) {
+            throw new RestTemplateException(response.getHeader().getResultMessage());
+        }
+    }
+
+    @Override
+    public void deleteAddress(Long id) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Void> requestEntity = new HttpEntity<>(httpHeaders);
+
+        String url = UriComponentsBuilder.fromHttpUrl(gatewayUrl + "/shop/users/address/" + id)
+                .toUriString();
+
+        CommonResponse<Void> response = restTemplate.exchange(
+                        url,
+                        HttpMethod.DELETE,
+                        requestEntity,
+                        COMMON_RESPONSE)
+                .getBody();
+        if (response == null) {
+            throw new RestTemplateException();
+        }
+        if (!response.getHeader().isSuccessful()) {
+            throw new RestTemplateException(response.getHeader().getResultMessage());
+        }
+    }
 }

--- a/src/main/java/shop/bookbom/front/domain/address/controller/AddressController.java
+++ b/src/main/java/shop/bookbom/front/domain/address/controller/AddressController.java
@@ -1,0 +1,21 @@
+package shop.bookbom.front.domain.address.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import shop.bookbom.front.domain.address.service.AddressService;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping
+public class AddressController {
+    private final AddressService addressService;
+
+    @GetMapping("/users/address")
+    public String addresses(Model model) {
+        model.addAttribute("addresses", addressService.getAddressBook());
+        return "page/user/address";
+    }
+}

--- a/src/main/java/shop/bookbom/front/domain/address/controller/AddressController.java
+++ b/src/main/java/shop/bookbom/front/domain/address/controller/AddressController.java
@@ -1,10 +1,15 @@
 package shop.bookbom.front.domain.address.controller;
 
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import shop.bookbom.front.domain.address.dto.request.AddressRequest;
 import shop.bookbom.front.domain.address.service.AddressService;
 
 @Controller
@@ -17,5 +22,19 @@ public class AddressController {
     public String addresses(Model model) {
         model.addAttribute("addresses", addressService.getAddressBook());
         return "page/user/address";
+    }
+
+    @GetMapping("/users/address/add")
+    public String addAddressPage(@ModelAttribute("addressRequest") AddressRequest addressRequest) {
+        return "page/user/address-add";
+    }
+
+    @PostMapping("/users/address/add")
+    public String addAddress(@ModelAttribute @Valid AddressRequest addressRequest, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return "page/user/address-add";
+        }
+        addressService.saveAddress(addressRequest);
+        return "redirect:/users/address";
     }
 }

--- a/src/main/java/shop/bookbom/front/domain/address/controller/AddressController.java
+++ b/src/main/java/shop/bookbom/front/domain/address/controller/AddressController.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import shop.bookbom.front.domain.address.dto.request.AddressRequest;
@@ -35,6 +37,18 @@ public class AddressController {
             return "page/user/address-add";
         }
         addressService.saveAddress(addressRequest);
+        return "redirect:/users/address";
+    }
+
+    @PostMapping("/users/address/default/{addressId}")
+    public String defaultAddress(@PathVariable("addressId") Long id) {
+        addressService.updateDefaultAddress(id);
+        return "redirect:/users/address";
+    }
+
+    @DeleteMapping("/users/address/delete/{addressId}")
+    public String deleteAddress(@PathVariable("addressId") Long id) {
+        addressService.deleteAddress(id);
         return "redirect:/users/address";
     }
 }

--- a/src/main/java/shop/bookbom/front/domain/address/dto/AddressResponse.java
+++ b/src/main/java/shop/bookbom/front/domain/address/dto/AddressResponse.java
@@ -1,0 +1,25 @@
+package shop.bookbom.front.domain.address.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AddressResponse implements Comparable<AddressResponse> {
+    private Long id;
+    private String nickname;
+    private String zipCode;
+    private String address;
+    private String addressDetail;
+    private boolean defaultAddress;
+
+    @Override
+    public int compareTo(AddressResponse other) {
+        if (this.defaultAddress && !other.defaultAddress) {
+            return -1;
+        } else if (!this.defaultAddress && other.defaultAddress) {
+            return 1;
+        }
+        return Long.compare(this.id, other.id);
+    }
+}

--- a/src/main/java/shop/bookbom/front/domain/address/dto/request/AddressRequest.java
+++ b/src/main/java/shop/bookbom/front/domain/address/dto/request/AddressRequest.java
@@ -1,0 +1,20 @@
+package shop.bookbom.front.domain.address.dto.request;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class AddressRequest {
+    private String nickname;
+    @Size(min = 5, max = 5, message = "우편번호는 5자리여야 합니다.")
+    private String zipcode;
+    @NotEmpty(message = "주소를 입력해주세요.")
+    private String address;
+    @NotEmpty(message = "상세 주소를 입력해주세요.")
+    private String addressDetail;
+}

--- a/src/main/java/shop/bookbom/front/domain/address/service/AddressService.java
+++ b/src/main/java/shop/bookbom/front/domain/address/service/AddressService.java
@@ -17,4 +17,18 @@ public interface AddressService {
      * request 주소 저장 요청
      */
     void saveAddress(AddressRequest request);
+
+    /**
+     * 기본 주소지로 설정하는 메서드입니다.
+     *
+     * @param id 주소 id
+     */
+    void updateDefaultAddress(Long id);
+
+    /**
+     * 주소를 삭제하는 메서드입니다.
+     *
+     * @param id 주소 id
+     */
+    void deleteAddress(Long id);
 }

--- a/src/main/java/shop/bookbom/front/domain/address/service/AddressService.java
+++ b/src/main/java/shop/bookbom/front/domain/address/service/AddressService.java
@@ -1,0 +1,8 @@
+package shop.bookbom.front.domain.address.service;
+
+import java.util.List;
+import shop.bookbom.front.domain.address.dto.AddressResponse;
+
+public interface AddressService {
+    List<AddressResponse> getAddressBook();
+}

--- a/src/main/java/shop/bookbom/front/domain/address/service/AddressService.java
+++ b/src/main/java/shop/bookbom/front/domain/address/service/AddressService.java
@@ -2,7 +2,19 @@ package shop.bookbom.front.domain.address.service;
 
 import java.util.List;
 import shop.bookbom.front.domain.address.dto.AddressResponse;
+import shop.bookbom.front.domain.address.dto.request.AddressRequest;
 
 public interface AddressService {
+    /**
+     * 회원의 주소록을 조회하는 메서드입니다.
+     *
+     * @return 회원의 주소록
+     */
     List<AddressResponse> getAddressBook();
+
+    /**
+     * 주소를 저장하는 메서드입니다.
+     * request 주소 저장 요청
+     */
+    void saveAddress(AddressRequest request);
 }

--- a/src/main/java/shop/bookbom/front/domain/address/service/AddressServiceImpl.java
+++ b/src/main/java/shop/bookbom/front/domain/address/service/AddressServiceImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import shop.bookbom.front.domain.address.adapter.AddressAdapter;
 import shop.bookbom.front.domain.address.dto.AddressResponse;
+import shop.bookbom.front.domain.address.dto.request.AddressRequest;
 
 @Service
 @RequiredArgsConstructor
@@ -17,5 +18,10 @@ public class AddressServiceImpl implements AddressService {
         List<AddressResponse> addresses = addressAdapter.getAddressBook();
         Collections.sort(addresses);
         return addresses;
+    }
+
+    @Override
+    public void saveAddress(AddressRequest request) {
+        addressAdapter.saveAddress(request);
     }
 }

--- a/src/main/java/shop/bookbom/front/domain/address/service/AddressServiceImpl.java
+++ b/src/main/java/shop/bookbom/front/domain/address/service/AddressServiceImpl.java
@@ -24,4 +24,14 @@ public class AddressServiceImpl implements AddressService {
     public void saveAddress(AddressRequest request) {
         addressAdapter.saveAddress(request);
     }
+
+    @Override
+    public void updateDefaultAddress(Long id) {
+        addressAdapter.updateDefaultAddress(id);
+    }
+
+    @Override
+    public void deleteAddress(Long id) {
+        addressAdapter.deleteAddress(id);
+    }
 }

--- a/src/main/java/shop/bookbom/front/domain/address/service/AddressServiceImpl.java
+++ b/src/main/java/shop/bookbom/front/domain/address/service/AddressServiceImpl.java
@@ -1,0 +1,21 @@
+package shop.bookbom.front.domain.address.service;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import shop.bookbom.front.domain.address.adapter.AddressAdapter;
+import shop.bookbom.front.domain.address.dto.AddressResponse;
+
+@Service
+@RequiredArgsConstructor
+public class AddressServiceImpl implements AddressService {
+    private final AddressAdapter addressAdapter;
+
+    @Override
+    public List<AddressResponse> getAddressBook() {
+        List<AddressResponse> addresses = addressAdapter.getAddressBook();
+        Collections.sort(addresses);
+        return addresses;
+    }
+}

--- a/src/main/java/shop/bookbom/front/domain/user/controller/UserController.java
+++ b/src/main/java/shop/bookbom/front/domain/user/controller/UserController.java
@@ -77,4 +77,9 @@ public class UserController {
     public String signUpSuccess() {
         return "page/user/sign-up-success";
     }
+
+    @GetMapping("/users/addresses")
+    public String addresses() {
+        return "page/user/address";
+    }
 }

--- a/src/main/java/shop/bookbom/front/domain/user/controller/UserController.java
+++ b/src/main/java/shop/bookbom/front/domain/user/controller/UserController.java
@@ -77,9 +77,4 @@ public class UserController {
     public String signUpSuccess() {
         return "page/user/sign-up-success";
     }
-
-    @GetMapping("/users/addresses")
-    public String addresses() {
-        return "page/user/address";
-    }
 }

--- a/src/main/resources/static/css/page/user/address.css
+++ b/src/main/resources/static/css/page/user/address.css
@@ -1,0 +1,4 @@
+.field-error {
+    border-color: #dc3545;
+    color: #dc3545;
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -175,7 +175,7 @@ body {
 
 .btn-outline-primary {
     transition: all 0.3s ease-in;
-    padding: 1.2rem 3rem;
+    /*padding: 1.2rem 3rem;*/
     letter-spacing: 0.02375rem;
     --bs-btn-color: #DEAD6F;
     --bs-btn-border-color: #DEAD6F;

--- a/src/main/resources/static/js/page/user/address.js
+++ b/src/main/resources/static/js/page/user/address.js
@@ -1,0 +1,40 @@
+function daumPostCode() {
+    new daum.Postcode({
+        oncomplete: function (data) {
+            // 팝업에서 검색결과 항목을 클릭했을때 실행할 코드를 작성하는 부분.
+
+            // 도로명 주소의 노출 규칙에 따라 주소를 표시한다.
+            // 내려오는 변수가 값이 없는 경우엔 공백('')값을 가지므로, 이를 참고하여 분기 한다.
+            var roadAddr = data.roadAddress; // 도로명 주소 변수
+            var extraRoadAddr = ''; // 참고 항목 변수
+
+            // 법정동명이 있을 경우 추가한다. (법정리는 제외)
+            // 법정동의 경우 마지막 문자가 "동/로/가"로 끝난다.
+            if (data.bname !== '' && /[동|로|가]$/g.test(data.bname)) {
+                extraRoadAddr += data.bname;
+            }
+            // 건물명이 있고, 공동주택일 경우 추가한다.
+            if (data.buildingName !== '' && data.apartment === 'Y') {
+                extraRoadAddr += (extraRoadAddr !== '' ? ', ' + data.buildingName : data.buildingName);
+            }
+            // 표시할 참고항목이 있을 경우, 괄호까지 추가한 최종 문자열을 만든다.
+            if (extraRoadAddr !== '') {
+                extraRoadAddr = ' (' + extraRoadAddr + ')';
+            }
+
+            // 우편번호와 주소 정보를 해당 필드에 넣는다.
+            let zipCode = document.getElementById('zipCode');
+            zipCode.value = data.zonecode;
+            zipCode.classList.remove('field-error');
+            let address = document.getElementById("address");
+            address.value = roadAddr;
+            address.classList.remove('field-error');
+            let addressDetail = document.getElementById("addressDetail");
+            addressDetail.classList.remove('field-error');
+            let errorElements = document.querySelectorAll('.field-error');
+            errorElements.forEach(element => {
+                element.style.display = 'none';
+            });
+        }
+    }).open();
+}

--- a/src/main/resources/templates/page/error.html
+++ b/src/main/resources/templates/page/error.html
@@ -22,8 +22,16 @@
         <p class="lead text-gray-800 mb-5" th:text="${message}">에러가 발생했습니다.</p>
         <p class="text-gray-500 mb-0" th:text="${errorCode}">It looks like you found a glitch in the matrix...</p>
         <a href="/">← 메인 페이지로 이동</a>
+        <div>
+            <button class="btn btn-outline-secondary" onclick="goBack()">뒤로가기</button>
+        </div>
     </div>
 </div>
+<script>
+    function goBack() {
+        window.history.back();
+    }
+</script>
 </body>
 </html>
 

--- a/src/main/resources/templates/page/user/address-add.html
+++ b/src/main/resources/templates/page/user/address-add.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ko"
+      layout:decorate="~{layouts/default_layout}"
+      xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" xmlns:th="http://www.thymeleaf.org">
+
+<th:block layout:fragment="css">
+    <link rel="stylesheet" th:href="@{/css/page/user/address.css}">
+</th:block>
+<th:block layout:fragment="script">
+    <script th:src="@{/js/page/user/address.js}"></script>
+    <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+</th:block>
+
+<div class="container mt-5 col-md-6" layout:fragment="content">
+    <h2 class="mb-4">주소 등록</h2>
+    <form action="/users/address/add" method="post" th:object="${addressRequest}">
+        <div class="mb-3 col-md-6">
+            <label class="form-label" for="nickname">별칭</label>
+            <input class="form-control" id="nickname" name="nickname" placeholder="별칭 입력" type="text">
+        </div>
+        <div class="mb-3 col-md-5">
+            <label class="form-label" for="zipCode">우편번호</label>
+            <div class="d-flex">
+                <input class="form-control col-md-1 mr-4" id="zipCode" placeholder="우편번호 입력" readonly
+                       th:errorclass="field-error"
+                       th:field="*{zipcode}"
+                       type="text">
+                <button class="btn btn-outline-secondary col-md-2 mx-4" onclick="daumPostCode()" type="button">찾기
+                </button>
+            </div>
+            <div class="field-error" th:errors="*{zipcode}"></div>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="address">주소</label>
+            <input class="form-control" id="address" name="address" placeholder="주소 입력" readonly
+                   th:errorclass="field-error"
+                   th:field="*{address}"
+                   type="text">
+            <div class="field-error" th:errors="*{address}"></div>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="addressDetail">주소 상세</label>
+            <input class="form-control" id="addressDetail" placeholder="상세 주소 입력"
+                   th:errorclass="field-error"
+                   th:field="*{addressDetail}"
+                   type="text">
+            <div class="field-error" th:errors="*{addressDetail}"></div>
+        </div>
+        <button class="btn btn-primary" type="submit">등록하기</button>
+    </form>
+</div>
+</html>

--- a/src/main/resources/templates/page/user/address.html
+++ b/src/main/resources/templates/page/user/address.html
@@ -24,14 +24,21 @@
             </span>
                     <span th:text="${address.zipCode}"></span>
                     <span th:text="${address.address}"></span>
+                    <span th:text="${address.addressDetail}"></span>
                 </div>
                 <div class="d-flex flex-column mx-2">
-                    <button class="btn btn-primary justify-content-center" th:if="${!address.defaultAddress}">기본 배송지
-                        등록
-                    </button>
-                    <div class="d-flex justify-content-end mt-2">
-                        <span class="fw-bold mx-2">수정</span>
-                        <span class="fw-bold mx-2">삭제</span>
+                    <form id="defaultAddressForm" method="post"
+                          th:action="@{'/users/address/default/' + ${address.id}}">
+                        <button class="btn btn-outline-primary default-address-btn justify-content-center"
+                                th:if="${!address.defaultAddress}"
+                                type="submit">기본 배송지 등록
+                        </button>
+                    </form>
+                    <div class="d-flex justify-content-end align-items-center mt-2">
+                        <form id="deleteAddressForm" th:action="@{'/users/address/delete/' + ${address.id}}"
+                              th:method="delete">
+                            <button class="btn btn-danger mx-2" type="submit">삭제</button>
+                        </form>
                     </div>
                 </div>
             </li>

--- a/src/main/resources/templates/page/user/address.html
+++ b/src/main/resources/templates/page/user/address.html
@@ -37,7 +37,7 @@
             </li>
         </ul>
         <div class="d-flex justify-content-center mt-3">
-            <button class="btn btn-primary col-md-3">주소 등록</button>
+            <a class="btn btn-primary col-md-3" href="/users/address/add">주소 등록</a>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/page/user/address.html
+++ b/src/main/resources/templates/page/user/address.html
@@ -36,7 +36,7 @@
                     </form>
                     <div class="d-flex justify-content-end align-items-center mt-2">
                         <form id="deleteAddressForm" th:action="@{'/users/address/delete/' + ${address.id}}"
-                              th:method="delete">
+                              th:if="${addresses.size() != 1}" th:method="delete">
                             <button class="btn btn-danger mx-2" type="submit">삭제</button>
                         </form>
                     </div>

--- a/src/main/resources/templates/page/user/address.html
+++ b/src/main/resources/templates/page/user/address.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="ko"
+      layout:decorate="~{layouts/default_layout}"
+      xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" xmlns:th="http://www.thymeleaf.org">
+
+<th:block layout:fragment="css">
+    <link rel="stylesheet" th:href="@{/css/page/user/address.css}">
+</th:block>
+<th:block layout:fragment="script">
+    <script th:src="@{/js/page/user/address.js}"></script>
+</th:block>
+
+<!-- Content -->
+<div class="d-flex flex-column align-items-center" layout:fragment="content">
+    <span class="fw-bold fs-2">나의 주소록</span>
+    <div class="card mt-3 col-md-6">
+        <ul class="list-group list-group-flush">
+            <li class="list-group-item d-flex justify-content-between">
+                <div class="d-flex flex-column">
+                    <span>
+                    <span class="fw-bold">Home</span><span class="mx-2">(기본 배송지)</span>
+                    </span>
+                    <span>12345</span>
+                    <span>1234 Main Street</span>
+                </div>
+                <div class="d-flex flex-column mx-2 justify-content-center">
+                    <div class="d-flex justify-content-end mt-2">
+                        <span class="fw-bold mx-2">수정</span>
+                        <span class="fw-bold mx-2">삭제</span>
+                    </div>
+                </div>
+            </li>
+            <li class="list-group-item d-flex justify-content-between">
+                <div class="d-flex flex-column">
+                    <span>
+                    <span class="fw-bold">Home</span><span class="mx-2">(기본 배송지)</span>
+                    </span>
+                    <span>12345</span>
+                    <span>1234 Main Street</span>
+                </div>
+                <div class="d-flex flex-column mx-2">
+                    <button class="btn btn-primary justify-content-center">기본 배송지 등록</button>
+                    <div class="d-flex justify-content-end mt-2">
+                        <span class="fw-bold mx-2">수정</span>
+                        <span class="fw-bold mx-2">삭제</span>
+                    </div>
+                </div>
+            </li>
+
+            <li class="list-group-item d-flex justify-content-between">
+                <div class="d-flex flex-column">
+                    <span>
+                    <span class="fw-bold">Home</span><span class="mx-2">(기본 배송지)</span>
+                    </span>
+                    <span>12345</span>
+                    <span>1234 Main Street</span>
+                </div>
+                <div class="d-flex flex-column mx-2 justify-content-center">
+                    <button class="btn btn-primary">기본 배송지 등록</button>
+                    <div class="d-flex justify-content-end mt-2">
+                        <span class="fw-bold mx-2">수정</span>
+                        <span class="fw-bold mx-2">삭제</span>
+                    </div>
+                </div>
+            </li>
+        </ul>
+        <div class="d-flex justify-content-center mt-3"> <!-- 중앙 정렬 -->
+            <button class="btn btn-primary col-md-3">주소 등록</button>
+        </div>
+    </div>
+</div>
+</html>

--- a/src/main/resources/templates/page/user/address.html
+++ b/src/main/resources/templates/page/user/address.html
@@ -16,48 +16,19 @@
     <span class="fw-bold fs-2">나의 주소록</span>
     <div class="card mt-3 col-md-6">
         <ul class="list-group list-group-flush">
-            <li class="list-group-item d-flex justify-content-between">
+            <li class="list-group-item d-flex justify-content-between" th:each="address : ${addresses}">
                 <div class="d-flex flex-column">
-                    <span>
-                    <span class="fw-bold">Home</span><span class="mx-2">(기본 배송지)</span>
-                    </span>
-                    <span>12345</span>
-                    <span>1234 Main Street</span>
-                </div>
-                <div class="d-flex flex-column mx-2 justify-content-center">
-                    <div class="d-flex justify-content-end mt-2">
-                        <span class="fw-bold mx-2">수정</span>
-                        <span class="fw-bold mx-2">삭제</span>
-                    </div>
-                </div>
-            </li>
-            <li class="list-group-item d-flex justify-content-between">
-                <div class="d-flex flex-column">
-                    <span>
-                    <span class="fw-bold">Home</span><span class="mx-2">(기본 배송지)</span>
-                    </span>
-                    <span>12345</span>
-                    <span>1234 Main Street</span>
+            <span>
+                <span class="fw-bold" th:text="${address.nickname}"></span>
+                <span class="mx-2" th:if="${address.defaultAddress}">(기본 배송지)</span>
+            </span>
+                    <span th:text="${address.zipCode}"></span>
+                    <span th:text="${address.address}"></span>
                 </div>
                 <div class="d-flex flex-column mx-2">
-                    <button class="btn btn-primary justify-content-center">기본 배송지 등록</button>
-                    <div class="d-flex justify-content-end mt-2">
-                        <span class="fw-bold mx-2">수정</span>
-                        <span class="fw-bold mx-2">삭제</span>
-                    </div>
-                </div>
-            </li>
-
-            <li class="list-group-item d-flex justify-content-between">
-                <div class="d-flex flex-column">
-                    <span>
-                    <span class="fw-bold">Home</span><span class="mx-2">(기본 배송지)</span>
-                    </span>
-                    <span>12345</span>
-                    <span>1234 Main Street</span>
-                </div>
-                <div class="d-flex flex-column mx-2 justify-content-center">
-                    <button class="btn btn-primary">기본 배송지 등록</button>
+                    <button class="btn btn-primary justify-content-center" th:if="${!address.defaultAddress}">기본 배송지
+                        등록
+                    </button>
                     <div class="d-flex justify-content-end mt-2">
                         <span class="fw-bold mx-2">수정</span>
                         <span class="fw-bold mx-2">삭제</span>
@@ -65,7 +36,7 @@
                 </div>
             </li>
         </ul>
-        <div class="d-flex justify-content-center mt-3"> <!-- 중앙 정렬 -->
+        <div class="d-flex justify-content-center mt-3">
             <button class="btn btn-primary col-md-3">주소 등록</button>
         </div>
     </div>

--- a/src/main/resources/templates/page/user/my-page.html
+++ b/src/main/resources/templates/page/user/my-page.html
@@ -35,7 +35,7 @@
             <ul class="list-group mb-3">
                 <li class="list-group-item member-link">회원 정보 수정</li>
                 <li class="list-group-item member-link">비밀 번호 수정</li>
-                <li class="list-group-item member-link" th:data-href="@{/users/addresses}">나의 주소록</li>
+                <li class="list-group-item member-link" th:data-href="@{/users/address}">나의 주소록</li>
                 <li class="list-group-item member-link">나의 리뷰 목록</li>
                 <li class="list-group-item member-link">나의 회원 등급</li>
             </ul>

--- a/src/main/resources/templates/page/user/my-page.html
+++ b/src/main/resources/templates/page/user/my-page.html
@@ -35,7 +35,7 @@
             <ul class="list-group mb-3">
                 <li class="list-group-item member-link">회원 정보 수정</li>
                 <li class="list-group-item member-link">비밀 번호 수정</li>
-                <li class="list-group-item member-link">나의 주소록</li>
+                <li class="list-group-item member-link" th:data-href="@{/users/addresses}">나의 주소록</li>
                 <li class="list-group-item member-link">나의 리뷰 목록</li>
                 <li class="list-group-item member-link">나의 회원 등급</li>
             </ul>


### PR DESCRIPTION
# 설명
- 회원 주소록 기능을 구현하였습니다

# 작업내용
- 회원의 주소 목록을 조회할 수 있습니다.
- 카카오 주소 API를 이용해 주소를 등록할 수 있습니다.
- 기본 배송지로 설정할 주소를 선택할 수 있습니다.
- 주소록에서 주소를 삭제할 수 있습니다.
![image](https://github.com/nhnacademy-be5-bom/bookbom-front/assets/95916780/d66a2edd-f236-406e-965e-57d369eb00ee)

![image](https://github.com/nhnacademy-be5-bom/bookbom-front/assets/95916780/2ce99255-7559-4343-9429-8c6710bdd2f7)
