### PR TITLE
[feat] 메인 페이지 캐싱 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
             <artifactId>validation-api</artifactId>
             <version>2.0.0.Final</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/shop/bookbom/front/FrontApplication.java
+++ b/src/main/java/shop/bookbom/front/FrontApplication.java
@@ -4,11 +4,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @EnableFeignClients
 @ConfigurationPropertiesScan
+@EnableCaching
 public class FrontApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/shop/bookbom/front/common/CommonPage.java
+++ b/src/main/java/shop/bookbom/front/common/CommonPage.java
@@ -1,15 +1,18 @@
 package shop.bookbom.front.common;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-public class CommonPage<T> extends PageImpl<T> {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CommonPage<T> extends PageImpl<T> implements Serializable {
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public CommonPage(
             @JsonProperty("content") List<T> content,

--- a/src/main/java/shop/bookbom/front/config/CacheConfig.java
+++ b/src/main/java/shop/bookbom/front/config/CacheConfig.java
@@ -1,0 +1,18 @@
+package shop.bookbom.front.config;
+
+import java.util.List;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CacheConfig {
+    @Bean
+    public CacheManager cacheManager() {
+        ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager();
+        cacheManager.setAllowNullValues(false);
+        cacheManager.setCacheNames(List.of("category", "main"));
+        return cacheManager;
+    }
+}

--- a/src/main/java/shop/bookbom/front/config/CacheConfig.java
+++ b/src/main/java/shop/bookbom/front/config/CacheConfig.java
@@ -1,18 +1,55 @@
 package shop.bookbom.front.config;
 
-import java.util.List;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class CacheConfig {
+    private final ObjectMapper objectMapper;
+    private final RedisConnectionFactory redisConnectionFactory;
+
+    public CacheConfig(RedisConnectionFactory redisConnectionFactory) {
+        this.redisConnectionFactory = redisConnectionFactory;
+
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator
+                .builder()
+                .allowIfSubType(Object.class)
+                .build();
+
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+        this.objectMapper.registerModule(new JavaTimeModule());
+        this.objectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+    }
+
     @Bean
-    public CacheManager cacheManager() {
-        ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager();
-        cacheManager.setAllowNullValues(false);
-        cacheManager.setCacheNames(List.of("category", "main"));
-        return cacheManager;
+    public RedisCacheManager redisCacheManager() {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer(this.objectMapper)))
+                .entryTtl(Duration.ofMinutes(10));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
     }
 }

--- a/src/main/java/shop/bookbom/front/domain/category/service/CategoryService.java
+++ b/src/main/java/shop/bookbom/front/domain/category/service/CategoryService.java
@@ -3,6 +3,8 @@ package shop.bookbom.front.domain.category.service;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import shop.bookbom.front.common.CommonListResponse;
 import shop.bookbom.front.common.CommonResponse;
@@ -13,6 +15,7 @@ import shop.bookbom.front.domain.category.dto.response.CategoryNameAndChildRespo
 
 @Service("CategoryService")
 @RequiredArgsConstructor
+@CacheConfig(cacheNames = "category")
 public class CategoryService {
     private final CategoryAdapter categoryAdaptor;
 
@@ -22,12 +25,14 @@ public class CategoryService {
         return (CategoryDepthResponse) response.getResult();
     }
 
+    @Cacheable(key = "'depth1'", unless = "#result.isEmpty()")
     public List<CategoryDTO> getDepthOneCategories() {
         CommonListResponse<CategoryDTO> response = categoryAdaptor.getDepthOneCategories();
         // null 없으므로 체크하지 않음
         return response.getResult();
     }
 
+    @Cacheable(key = "'childCategory' + #categoryId", unless = "#result == null")
     public CommonListResponse<CategoryDTO> getChildCategoriesById(Long categoryId) {
         return categoryAdaptor.getChildCategoriesOf(categoryId);
     }

--- a/src/main/java/shop/bookbom/front/index/service/impl/IndexServiceImpl.java
+++ b/src/main/java/shop/bookbom/front/index/service/impl/IndexServiceImpl.java
@@ -1,6 +1,8 @@
 package shop.bookbom.front.index.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -10,15 +12,18 @@ import shop.bookbom.front.index.service.IndexService;
 
 @Service
 @RequiredArgsConstructor
+@CacheConfig(cacheNames = "main")
 public class IndexServiceImpl implements IndexService {
     private final IndexAdapter indexAdapter;
 
     @Override
+    @Cacheable(key = "'latestBooks'", condition = "#pageable.pageNumber == 0 && #pageable.pageSize == 8")
     public Page<BookSearchResponse> mainLatestBooks(Pageable pageable) {
         return indexAdapter.mainLatestBooks(pageable);
     }
 
     @Override
+    @Cacheable(key = "'bestBooks'", condition = "#pageable.pageNumber == 0 && #pageable.pageSize == 8")
     public Page<BookSearchResponse> mainBestBooks(Pageable pageable) {
         return indexAdapter.mainBestBooks(pageable);
     }


### PR DESCRIPTION
# 설명
- Spring Cache를 사용해서 메인 페이지를 캐싱해서 성능을 개선시켰습니다.
  
# 작업내용
- Spring Cache 적용
- 메인페이지 도서 조회, 헤더에 카테고리 조회 시 캐싱 기능 적용
 
